### PR TITLE
Fix sql guid caster reflection type load exception

### DIFF
--- a/backend/YemenBooking.Api/Program.cs
+++ b/backend/YemenBooking.Api/Program.cs
@@ -104,10 +104,10 @@ builder.Services.AddMediatR(cfg => {
     cfg.RegisterServicesFromAssembly(typeof(GetPropertyDetailsQueryHandler).Assembly);
 });
 
-// إضافة AutoMapper وتهيئة ملفات Mapping يدويًا لتجنب خطأ MissingMethodException
+// إضافة AutoMapper مع تقييد البحث على مجلد Mappings في طبقة Application
 builder.Services.AddAutoMapper(
-    cfg => cfg.AddMaps(AppDomain.CurrentDomain.GetAssemblies()),
-    AppDomain.CurrentDomain.GetAssemblies());
+    cfg => cfg.AddMaps(typeof(QueryMappingProfile).Assembly),
+    typeof(QueryMappingProfile).Assembly);
 
 // إضافة خدمات المشروع
 builder.Services.AddYemenBookingServices();

--- a/backend/YemenBooking.Application/Handlers/Queries/MobileApp/Booking/GetUserBookingSummaryQueryHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Queries/MobileApp/Booking/GetUserBookingSummaryQueryHandler.cs
@@ -69,14 +69,10 @@ public class GetUserBookingSummaryQueryHandler : IRequestHandler<GetUserBookingS
             // تحديد السنة المطلوبة
             var targetYear = request.Year ?? DateTime.Now.Year;
 
-            // جلب ملخص الحجوزات الشهرية، وأكثر العقارات حجزاً، وأكثر المدن زيارة بشكل متوازٍ
-            var monthlyTask = GetMonthlyBookingSummary(request.UserId, targetYear, cancellationToken);
-            var topPropsTask = GetTopBookedProperties(request.UserId, 5, cancellationToken);
-            var topCitiesTask = GetTopVisitedCities(request.UserId, 5, cancellationToken);
-            await Task.WhenAll(monthlyTask, topPropsTask, topCitiesTask);
-            var monthlyBookings = monthlyTask.Result;
-            var topBookedProperties = topPropsTask.Result;
-            var topVisitedCities = topCitiesTask.Result;
+            // جلب ملخص الحجوزات الشهرية، وأكثر العقارات حجزاً، وأكثر المدن زيارة بشكل تسلسلي
+            var monthlyBookings = await GetMonthlyBookingSummary(request.UserId, targetYear, cancellationToken);
+            var topBookedProperties = await GetTopBookedProperties(request.UserId, 5, cancellationToken);
+            var topVisitedCities = await GetTopVisitedCities(request.UserId, 5, cancellationToken);
 
             // إنشاء DTO للاستجابة
             var summaryDto = new UserBookingSummaryDto

--- a/backend/YemenBooking.Infrastructure/YemenBooking.Infrastructure.csproj
+++ b/backend/YemenBooking.Infrastructure/YemenBooking.Infrastructure.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="LiteDB" Version="5.0.21" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.6" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="FirebaseAdmin" Version="3.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />


### PR DESCRIPTION
Upgrade Microsoft.Data.SqlClient to 5.2.0 and narrow AutoMapper assembly scanning to fix `TypeLoadException`.

The `SqlGuidCaster` `TypeLoadException` is a known issue with `Microsoft.Data.SqlClient` versions prior to 5.2 when running on .NET 8. Restricting AutoMapper's assembly scanning to only the application's mapping assembly also prevents `ReflectionTypeLoadException` from incompatible types in unrelated assemblies.

---
<a href="https://cursor.com/background-agent?bcId=bc-7bfcedd0-e267-48fe-9205-c5c0916cf027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7bfcedd0-e267-48fe-9205-c5c0916cf027">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

