### PR TITLE
Ensure mobile control panel backend compatibility for admin reviews

### DIFF
--- a/control_panel_app/lib/features/admin_properties/data/models/property_image_model.dart
+++ b/control_panel_app/lib/features/admin_properties/data/models/property_image_model.dart
@@ -43,23 +43,27 @@ class PropertyImageModel extends PropertyImage {
   
   factory PropertyImageModel.fromJson(Map<String, dynamic> json) {
     return PropertyImageModel(
-      id: json['id'] as String,
-      url: json['url'] as String,
-      filename: json['filename'] as String,
-      size: json['size'] as int,
-      mimeType: json['mimeType'] as String,
-      width: json['width'] as int,
-      height: json['height'] as int,
+      id: (json['id'] ?? json['imageId']) as String,
+      url: (json['url'] ?? json['imageUrl'] ?? '') as String,
+      filename: (json['filename'] ?? json['name'] ?? '') as String,
+      size: (json['size'] as num?)?.toInt() ?? 0,
+      mimeType: (json['mimeType'] ?? json['type'] ?? 'image/jpeg') as String,
+      width: (json['width'] as num?)?.toInt() ?? 0,
+      height: (json['height'] as num?)?.toInt() ?? 0,
       alt: json['alt'] as String?,
-      uploadedAt: DateTime.parse(json['uploadedAt'] as String),
-      uploadedBy: json['uploadedBy'] as String,
-      order: json['order'] as int,
-      isPrimary: json['isPrimary'] as bool,
+      uploadedAt: json['uploadedAt'] != null
+          ? DateTime.parse(json['uploadedAt'] as String)
+          : DateTime.now(),
+      uploadedBy: (json['uploadedBy'] ?? json['ownerId'] ?? '') as String,
+      order: (json['order'] as num?)?.toInt() ?? 0,
+      isPrimary: (json['isPrimary'] as bool?) ?? false,
       propertyId: json['propertyId'] as String?,
-      category: _parseImageCategory(json['category']),
-      tags: (json['tags'] as List<dynamic>?)?.cast<String>() ?? [],
-      processingStatus: _parseProcessingStatus(json['processingStatus']),
-      thumbnails: ImageThumbnailsModel.fromJson(json['thumbnails']),
+      category: _parseImageCategory((json['category'] ?? 'gallery').toString()),
+      tags: (json['tags'] as List<dynamic>?)?.map((e) => e.toString()).toList() ?? [],
+      processingStatus: _parseProcessingStatus((json['processingStatus'] ?? 'ready').toString()),
+      thumbnails: json['thumbnails'] is Map<String, dynamic>
+          ? ImageThumbnailsModel.fromJson(json['thumbnails'] as Map<String, dynamic>)
+          : const ImageThumbnailsModel(small: '', medium: '', large: '', hd: ''),
     );
   }
   
@@ -176,10 +180,10 @@ class ImageThumbnailsModel extends ImageThumbnails {
   
   factory ImageThumbnailsModel.fromJson(Map<String, dynamic> json) {
     return ImageThumbnailsModel(
-      small: json['small'] as String,
-      medium: json['medium'] as String,
-      large: json['large'] as String,
-      hd: json['hd'] as String,
+      small: (json['small'] ?? json['s'] ?? '') as String,
+      medium: (json['medium'] ?? json['m'] ?? '') as String,
+      large: (json['large'] ?? json['l'] ?? '') as String,
+      hd: (json['hd'] ?? json['xl'] ?? '') as String,
     );
   }
   

--- a/control_panel_app/lib/features/admin_properties/presentation/widgets/property_stats_card.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/widgets/property_stats_card.dart
@@ -106,96 +106,104 @@ class _PropertyStatsCardState extends State<PropertyStatsCard>
                   filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
                   child: Padding(
                     padding: const EdgeInsets.all(16),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        Wrap(
-                          alignment: WrapAlignment.spaceBetween,
-                          crossAxisAlignment: WrapCrossAlignment.center,
-                          runAlignment: WrapAlignment.center,
-                          spacing: 8,
-                          runSpacing: 8,
-                          children: [
-                            Container(
-                              width: 36,
-                              height: 36,
-                              decoration: BoxDecoration(
-                                gradient: LinearGradient(
-                                  colors: [
-                                    widget.color.withValues(alpha: 0.3),
-                                    widget.color.withValues(alpha: 0.1),
-                                  ],
-                                ),
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: Icon(
-                                widget.icon,
-                                color: widget.color,
-                                size: 18,
-                              ),
-                            ),
-                            if (widget.trend != null)
-                              ConstrainedBox(
-                                constraints: const BoxConstraints(maxWidth: 140),
-                                child: Container(
-                                  padding: const EdgeInsets.symmetric(
-                                    horizontal: 8,
-                                    vertical: 4,
-                                  ),
-                                  decoration: BoxDecoration(
-                                    color: widget.isPositive
-                                        ? AppTheme.success.withValues(alpha: 0.1)
-                                        : AppTheme.error.withValues(alpha: 0.1),
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
-                                  child: Row(
-                                    mainAxisSize: MainAxisSize.min,
-                                    children: [
-                                      Icon(
-                                        widget.isPositive
-                                            ? Icons.trending_up_rounded
-                                            : Icons.trending_down_rounded,
-                                        size: 12,
-                                        color: widget.isPositive
-                                            ? AppTheme.success
-                                            : AppTheme.error,
-                                      ),
-                                      const SizedBox(width: 4),
-                                      Flexible(
-                                        child: Text(
-                                          widget.trend!,
-                                          overflow: TextOverflow.ellipsis,
-                                          style: AppTextStyles.caption.copyWith(
-                                            color: widget.isPositive
-                                                ? AppTheme.success
-                                                : AppTheme.error,
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                        ),
-                                      ),
+                    child: FittedBox(
+                      fit: BoxFit.scaleDown,
+                      alignment: Alignment.topLeft,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Wrap(
+                            alignment: WrapAlignment.spaceBetween,
+                            crossAxisAlignment: WrapCrossAlignment.center,
+                            runAlignment: WrapAlignment.center,
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: [
+                              Container(
+                                width: 36,
+                                height: 36,
+                                decoration: BoxDecoration(
+                                  gradient: LinearGradient(
+                                    colors: [
+                                      widget.color.withValues(alpha: 0.3),
+                                      widget.color.withValues(alpha: 0.1),
                                     ],
                                   ),
+                                  borderRadius: BorderRadius.circular(10),
+                                ),
+                                child: Icon(
+                                  widget.icon,
+                                  color: widget.color,
+                                  size: 18,
                                 ),
                               ),
-                          ],
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          widget.value,
-                          style: AppTextStyles.heading1.copyWith(
-                            color: AppTheme.textWhite,
-                            fontWeight: FontWeight.bold,
+                              if (widget.trend != null)
+                                ConstrainedBox(
+                                  constraints: const BoxConstraints(maxWidth: 140),
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 8,
+                                      vertical: 4,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: widget.isPositive
+                                          ? AppTheme.success.withValues(alpha: 0.1)
+                                          : AppTheme.error.withValues(alpha: 0.1),
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    child: Row(
+                                      mainAxisSize: MainAxisSize.min,
+                                      children: [
+                                        Icon(
+                                          widget.isPositive
+                                              ? Icons.trending_up_rounded
+                                              : Icons.trending_down_rounded,
+                                          size: 12,
+                                          color: widget.isPositive
+                                              ? AppTheme.success
+                                              : AppTheme.error,
+                                        ),
+                                        const SizedBox(width: 4),
+                                        Flexible(
+                                          child: Text(
+                                            widget.trend!,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: AppTextStyles.caption.copyWith(
+                                              color: widget.isPositive
+                                                  ? AppTheme.success
+                                                  : AppTheme.error,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                            ],
                           ),
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          widget.title,
-                          style: AppTextStyles.caption.copyWith(
-                            color: AppTheme.textMuted,
+                          const SizedBox(height: 8),
+                          Text(
+                            widget.value,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AppTextStyles.heading1.copyWith(
+                              color: AppTheme.textWhite,
+                              fontWeight: FontWeight.bold,
+                            ),
                           ),
-                        ),
-                      ],
+                          const SizedBox(height: 4),
+                          Text(
+                            widget.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AppTextStyles.caption.copyWith(
+                              color: AppTheme.textMuted,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/control_panel_app/lib/features/admin_properties/presentation/widgets/property_stats_card.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/widgets/property_stats_card.dart
@@ -108,10 +108,14 @@ class _PropertyStatsCardState extends State<PropertyStatsCard>
                     padding: const EdgeInsets.all(16),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisAlignment: MainAxisAlignment.start,
                       children: [
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        Wrap(
+                          alignment: WrapAlignment.spaceBetween,
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          runAlignment: WrapAlignment.center,
+                          spacing: 8,
+                          runSpacing: 8,
                           children: [
                             Container(
                               width: 36,
@@ -132,44 +136,51 @@ class _PropertyStatsCardState extends State<PropertyStatsCard>
                               ),
                             ),
                             if (widget.trend != null)
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 4,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: widget.isPositive
-                                      ? AppTheme.success.withValues(alpha: 0.1)
-                                      : AppTheme.error.withValues(alpha: 0.1),
-                                  borderRadius: BorderRadius.circular(12),
-                                ),
-                                child: Row(
-                                  children: [
-                                    Icon(
-                                      widget.isPositive
-                                          ? Icons.trending_up_rounded
-                                          : Icons.trending_down_rounded,
-                                      size: 12,
-                                      color: widget.isPositive
-                                          ? AppTheme.success
-                                          : AppTheme.error,
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      widget.trend!,
-                                      style: AppTextStyles.caption.copyWith(
+                              ConstrainedBox(
+                                constraints: const BoxConstraints(maxWidth: 140),
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 8,
+                                    vertical: 4,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: widget.isPositive
+                                        ? AppTheme.success.withValues(alpha: 0.1)
+                                        : AppTheme.error.withValues(alpha: 0.1),
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Icon(
+                                        widget.isPositive
+                                            ? Icons.trending_up_rounded
+                                            : Icons.trending_down_rounded,
+                                        size: 12,
                                         color: widget.isPositive
                                             ? AppTheme.success
                                             : AppTheme.error,
-                                        fontWeight: FontWeight.w600,
                                       ),
-                                    ),
-                                  ],
+                                      const SizedBox(width: 4),
+                                      Flexible(
+                                        child: Text(
+                                          widget.trend!,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: AppTextStyles.caption.copyWith(
+                                            color: widget.isPositive
+                                                ? AppTheme.success
+                                                : AppTheme.error,
+                                            fontWeight: FontWeight.w600,
+                                          ),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                           ],
                         ),
-                        const Spacer(),
+                        const SizedBox(height: 8),
                         Text(
                           widget.value,
                           style: AppTextStyles.heading1.copyWith(

--- a/control_panel_app/lib/features/admin_reviews/data/repositories/reviews_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_reviews/data/repositories/reviews_repository_impl.dart
@@ -25,6 +25,7 @@ class ReviewsRepositoryImpl implements ReviewsRepository {
     double? maxRating,
     bool? hasImages,
     String? propertyId,
+    String? unitId,
     String? userId,
     DateTime? startDate,
     DateTime? endDate,
@@ -38,6 +39,7 @@ class ReviewsRepositoryImpl implements ReviewsRepository {
         maxRating: maxRating,
         hasImages: hasImages,
         propertyId: propertyId,
+        unitId: unitId,
         userId: userId,
         startDate: startDate,
         endDate: endDate,
@@ -59,8 +61,13 @@ class ReviewsRepositoryImpl implements ReviewsRepository {
   @override
   Future<Either<Failure, Review>> getReviewDetails(String reviewId) async {
     try {
-      final review = await remoteDataSource.getReviewDetails(reviewId);
-      return Right(review);
+      // Backend does not expose GET /api/admin/reviews/{id}; fallback to cache
+      final cached = await localDataSource.getCachedReviews();
+      final match = cached.firstWhere(
+        (r) => r.id == reviewId,
+        orElse: () => throw ServerException('Review not found in cache'),
+      );
+      return Right(match);
     } on ServerException catch (e) {
       return Left(ServerFailure(e.message));
     } catch (e) {

--- a/control_panel_app/lib/features/admin_reviews/domain/repositories/reviews_repository.dart
+++ b/control_panel_app/lib/features/admin_reviews/domain/repositories/reviews_repository.dart
@@ -12,6 +12,7 @@ abstract class ReviewsRepository {
     double? maxRating,
     bool? hasImages,
     String? propertyId,
+    String? unitId,
     String? userId,
     DateTime? startDate,
     DateTime? endDate,

--- a/control_panel_app/lib/features/admin_reviews/domain/usecases/get_all_reviews_usecase.dart
+++ b/control_panel_app/lib/features/admin_reviews/domain/usecases/get_all_reviews_usecase.dart
@@ -12,6 +12,7 @@ class GetAllReviewsParams {
   final double? maxRating;
   final bool? hasImages;
   final String? propertyId;
+  final String? unitId;
   final String? userId;
   final DateTime? startDate;
   final DateTime? endDate;
@@ -24,6 +25,7 @@ class GetAllReviewsParams {
     this.maxRating,
     this.hasImages,
     this.propertyId,
+    this.unitId,
     this.userId,
     this.startDate,
     this.endDate,
@@ -45,6 +47,7 @@ class GetAllReviewsUseCase implements UseCase<List<Review>, GetAllReviewsParams>
       maxRating: params.maxRating,
       hasImages: params.hasImages,
       propertyId: params.propertyId,
+      unitId: params.unitId,
       userId: params.userId,
       startDate: params.startDate,
       endDate: params.endDate,

--- a/control_panel_app/lib/features/admin_reviews/presentation/pages/review_details_page.dart
+++ b/control_panel_app/lib/features/admin_reviews/presentation/pages/review_details_page.dart
@@ -9,6 +9,9 @@ import 'package:bookn_cp_app/core/theme/app_theme.dart';
 import 'package:bookn_cp_app/core/theme/app_text_styles.dart';
 import 'package:bookn_cp_app/core/theme/app_dimensions.dart';
 import '../../domain/entities/review.dart';
+import 'package:bookn_cp_app/injection_container.dart';
+import 'package:bookn_cp_app/services/local_storage_service.dart';
+import 'package:bookn_cp_app/core/constants/storage_constants.dart';
 import '../bloc/review_details/review_details_bloc.dart';
 import '../widgets/rating_breakdown_widget.dart';
 import '../widgets/review_images_gallery.dart';
@@ -537,11 +540,13 @@ class _ReviewDetailsPageState extends State<ReviewDetailsPage>
       builder: (context) => AddResponseDialog(
         reviewId: widget.review.id,
         onSubmit: (responseText) {
+          final String respondedBy =
+              (sl<LocalStorageService>().getData(StorageConstants.userId)?.toString() ?? '');
           context.read<ReviewDetailsBloc>().add(
             AddResponseEvent(
               reviewId: widget.review.id,
               responseText: responseText,
-              respondedBy: 'admin-id', // Get from auth
+              respondedBy: respondedBy,
             ),
           );
         },

--- a/control_panel_app/lib/features/property_types/presentation/bloc/unit_type_fields/unit_type_fields_bloc.dart
+++ b/control_panel_app/lib/features/property_types/presentation/bloc/unit_type_fields/unit_type_fields_bloc.dart
@@ -74,6 +74,13 @@ class UnitTypeFieldsBloc extends Bloc<UnitTypeFieldsEvent, UnitTypeFieldsState> 
   ) async {
     final currentState = state;
     
+    final Map<String, dynamic>? fieldOptions = event.fieldData['fieldOptions'] == null
+        ? null
+        : Map<String, dynamic>.from(event.fieldData['fieldOptions'] as Map);
+    final Map<String, dynamic>? validationRules = event.fieldData['validationRules'] == null
+        ? null
+        : Map<String, dynamic>.from(event.fieldData['validationRules'] as Map);
+
     final result = await createField(
       CreateFieldParams(
         unitTypeId: event.unitTypeId,
@@ -81,8 +88,8 @@ class UnitTypeFieldsBloc extends Bloc<UnitTypeFieldsEvent, UnitTypeFieldsState> 
         fieldName: event.fieldData['fieldName'],
         displayName: event.fieldData['displayName'],
         description: event.fieldData['description'],
-        fieldOptions: event.fieldData['fieldOptions'],
-        validationRules: event.fieldData['validationRules'],
+        fieldOptions: fieldOptions,
+        validationRules: validationRules,
         isRequired: event.fieldData['isRequired'],
         isSearchable: event.fieldData['isSearchable'],
         isPublic: event.fieldData['isPublic'],
@@ -117,14 +124,21 @@ class UnitTypeFieldsBloc extends Bloc<UnitTypeFieldsEvent, UnitTypeFieldsState> 
   ) async {
     final currentState = state;
     
+    final Map<String, dynamic>? fieldOptions = event.fieldData['fieldOptions'] == null
+        ? null
+        : Map<String, dynamic>.from(event.fieldData['fieldOptions'] as Map);
+    final Map<String, dynamic>? validationRules = event.fieldData['validationRules'] == null
+        ? null
+        : Map<String, dynamic>.from(event.fieldData['validationRules'] as Map);
+
     final result = await updateField(
       UpdateFieldParams(
         fieldId: event.fieldId,
         fieldName: event.fieldData['fieldName'],
         displayName: event.fieldData['displayName'],
         description: event.fieldData['description'],
-        fieldOptions: event.fieldData['fieldOptions'],
-        validationRules: event.fieldData['validationRules'],
+        fieldOptions: fieldOptions,
+        validationRules: validationRules,
         isRequired: event.fieldData['isRequired'],
         isSearchable: event.fieldData['isSearchable'],
         isPublic: event.fieldData['isPublic'],

--- a/control_panel_app/lib/features/property_types/presentation/pages/property_types_page.dart
+++ b/control_panel_app/lib/features/property_types/presentation/pages/property_types_page.dart
@@ -1249,28 +1249,32 @@ class _PropertyTypesPageState extends State<PropertyTypesPage>
       return;
     }
     
+    final fieldsBloc = context.read<UnitTypeFieldsBloc>();
     showDialog(
       context: context,
-      builder: (context) => UnitTypeFieldModal(
-        field: field,
-        unitTypeId: unitState.selectedUnitType!.id,
-        onSave: (fieldData) {
-          if (field != null) {
-            context.read<UnitTypeFieldsBloc>().add(
-              UpdateFieldEvent(
-                fieldId: field.fieldId,
-                fieldData: fieldData,
-              ),
-            );
-          } else {
-            context.read<UnitTypeFieldsBloc>().add(
-              CreateFieldEvent(
-                unitTypeId: unitState.selectedUnitType!.id,
-                fieldData: fieldData,
-              ),
-            );
-          }
-        },
+      builder: (dialogContext) => BlocProvider.value(
+        value: fieldsBloc,
+        child: UnitTypeFieldModal(
+          field: field,
+          unitTypeId: unitState.selectedUnitType!.id,
+          onSave: (fieldData) {
+            if (field != null) {
+              fieldsBloc.add(
+                UpdateFieldEvent(
+                  fieldId: field.fieldId,
+                  fieldData: fieldData,
+                ),
+              );
+            } else {
+              fieldsBloc.add(
+                CreateFieldEvent(
+                  unitTypeId: unitState.selectedUnitType!.id,
+                  fieldData: fieldData,
+                ),
+              );
+            }
+          },
+        ),
       ),
     );
   }

--- a/control_panel_app/lib/features/property_types/presentation/pages/property_types_page.dart
+++ b/control_panel_app/lib/features/property_types/presentation/pages/property_types_page.dart
@@ -1262,14 +1262,14 @@ class _PropertyTypesPageState extends State<PropertyTypesPage>
               fieldsBloc.add(
                 UpdateFieldEvent(
                   fieldId: field.fieldId,
-                  fieldData: fieldData,
+                  fieldData: Map<String, dynamic>.from(fieldData),
                 ),
               );
             } else {
               fieldsBloc.add(
                 CreateFieldEvent(
                   unitTypeId: unitState.selectedUnitType!.id,
-                  fieldData: fieldData,
+                  fieldData: Map<String, dynamic>.from(fieldData),
                 ),
               );
             }

--- a/control_panel_app/lib/features/property_types/presentation/widgets/unit_type_field_modal.dart
+++ b/control_panel_app/lib/features/property_types/presentation/widgets/unit_type_field_modal.dart
@@ -794,6 +794,7 @@ class _UnitTypeFieldModalState extends State<UnitTypeFieldModal>
             .where((e) => e.isNotEmpty)
             .toList();
       }
+      final validationRules = <String, dynamic>{};
       
       widget.onSave({
         'fieldTypeId': _selectedFieldType,
@@ -801,7 +802,7 @@ class _UnitTypeFieldModalState extends State<UnitTypeFieldModal>
         'displayName': _displayNameController.text,
         'description': _descriptionController.text,
         'fieldOptions': fieldOptions,
-        'validationRules': {},
+        'validationRules': validationRules,
         'isRequired': _isRequired,
         'isSearchable': _isSearchable,
         'isPublic': _isPublic,

--- a/control_panel_app/lib/injection_container.dart
+++ b/control_panel_app/lib/injection_container.dart
@@ -715,7 +715,12 @@ void _initAdminReviews() {
       ));
 
   // Data sources
-  sl.registerLazySingleton<ar_ds_remote.ReviewsRemoteDataSource>(() => ar_ds_remote.ReviewsRemoteDataSourceImpl(apiClient: sl()));
+  sl.registerLazySingleton<ar_ds_remote.ReviewsRemoteDataSource>(
+    () => ar_ds_remote.ReviewsRemoteDataSourceImpl(
+      apiClient: sl(),
+      localStorage: sl(),
+    ),
+  );
   sl.registerLazySingleton<ar_ds_local.ReviewsLocalDataSource>(() => ar_ds_local.ReviewsLocalDataSourceImpl(sharedPreferences: sl()));
 }
 


### PR DESCRIPTION
Align `admin_reviews` feature in the mobile control panel app with the backend API to resolve data source and endpoint incompatibilities.

The previous implementation of `admin_reviews` in the mobile app had several mismatches with the backend, including incorrect query parameter names for date ranges, missing `unitId` support, an `approveReview` endpoint that didn't send the required `adminId` in the body, and reliance on `rejectReview` and `getReviewDetails` endpoints that do not exist in the backend. This PR addresses these issues by standardizing API calls, leveraging local cache for review details, and disabling unsupported functionalities.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e98d7ab-a3df-4c2a-b77b-0fe9cb73aa42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7e98d7ab-a3df-4c2a-b77b-0fe9cb73aa42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

