### PR TITLE
Fix rendering overflow errors across app and backend

### DIFF
--- a/control_panel_app/lib/features/admin_users/presentation/pages/user_details_page.dart
+++ b/control_panel_app/lib/features/admin_users/presentation/pages/user_details_page.dart
@@ -751,8 +751,11 @@ class _UserDetailsPageState extends State<UserDetailsPage>
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              OverflowBar(
+                alignment: MainAxisAlignment.spaceBetween,
+                overflowAlignment: OverflowBarAlignment.center,
+                spacing: 8,
+                overflowSpacing: 4,
                 children: [
                   Container(
                     width: 32,
@@ -772,43 +775,45 @@ class _UserDetailsPageState extends State<UserDetailsPage>
                       size: 16,
                     ),
                   ),
-                  
                   if (trend != null)
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 6,
-                        vertical: 3,
-                      ),
-                      decoration: BoxDecoration(
-                        color: isPositive
-                            ? AppTheme.success.withOpacity(0.1)
-                            : AppTheme.error.withOpacity(0.1),
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            isPositive
-                                ? Icons.trending_up_rounded
-                                : Icons.trending_down_rounded,
-                            size: 10,
-                            color: isPositive
-                                ? AppTheme.success
-                                : AppTheme.error,
-                          ),
-                          const SizedBox(width: 2),
-                          Text(
-                            trend,
-                            style: TextStyle(
-                              fontSize: 10,
+                    FittedBox(
+                      fit: BoxFit.scaleDown,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 6,
+                          vertical: 3,
+                        ),
+                        decoration: BoxDecoration(
+                          color: isPositive
+                              ? AppTheme.success.withOpacity(0.1)
+                              : AppTheme.error.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(
+                              isPositive
+                                  ? Icons.trending_up_rounded
+                                  : Icons.trending_down_rounded,
+                              size: 10,
                               color: isPositive
                                   ? AppTheme.success
                                   : AppTheme.error,
-                              fontWeight: FontWeight.w600,
                             ),
-                          ),
-                        ],
+                            const SizedBox(width: 2),
+                            Text(
+                              trend,
+                              style: TextStyle(
+                                fontSize: 10,
+                                color: isPositive
+                                    ? AppTheme.success
+                                    : AppTheme.error,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
                 ],


### PR DESCRIPTION
Fixes RenderFlex overflow in the stat card header by replacing `Row` with `OverflowBar` and wrapping the trend chip in `FittedBox` to ensure proper layout on narrow screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-be9aa595-4636-4470-aa71-6e73d11d4fb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be9aa595-4636-4470-aa71-6e73d11d4fb5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

