### PR TITLE
Implement immediate image upload for creation

### DIFF
--- a/backend/YemenBooking.Api/Controllers/Images/ImagesController.cs
+++ b/backend/YemenBooking.Api/Controllers/Images/ImagesController.cs
@@ -41,6 +41,7 @@ namespace YemenBooking.Api.Controllers.Images
 
             var command = new UploadImageCommand
             {
+                TempKey = string.IsNullOrWhiteSpace(request.TempKey) ? null : request.TempKey,
                 File = new FileUploadRequest
                 {
                     FileName = request.File.FileName,
@@ -116,6 +117,23 @@ namespace YemenBooking.Api.Controllers.Images
                 limit = data.Limit,
                 totalPages = data.TotalPages
             });
+        }
+
+        /// <summary>
+        /// حذف جميع الصور التي تخص مفتاحاً مؤقتاً معيناً وتنظيف الملفات
+        /// Purge all images associated with a temporary key
+        /// </summary>
+        [HttpDelete("purge-temp")]
+        public async Task<IActionResult> PurgeTempImages([FromQuery] string tempKey)
+        {
+            if (string.IsNullOrWhiteSpace(tempKey))
+                return BadRequest("tempKey is required");
+
+            var result = await _mediator.Send(new DeleteImagesByTempKeyCommand { TempKey = tempKey });
+            if (!result.Success)
+                return BadRequest(result.Message);
+
+            return NoContent();
         }
 
         // /// <summary>

--- a/backend/YemenBooking.Api/Controllers/Images/UploadImageRequest.cs
+++ b/backend/YemenBooking.Api/Controllers/Images/UploadImageRequest.cs
@@ -12,6 +12,9 @@ namespace YemenBooking.Api.Controllers.Images
         [FromForm(Name = "file")]
         public IFormFile File { get; set; } = null!;
 
+        [FromForm(Name = "tempKey")]
+        public string? TempKey { get; set; }
+
         [FromForm(Name = "category")]
         public string Category { get; set; } = string.Empty;
 

--- a/backend/YemenBooking.Application/Commands/CP/Images/DeleteImagesCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Images/DeleteImagesCommand.cs
@@ -22,4 +22,14 @@ namespace YemenBooking.Application.Commands.Images
         /// </summary>
         public bool Permanent { get; set; } = false;
     }
+
+    /// <summary>
+    /// أمر لحذف الصور وفق مفتاح مؤقت
+    /// Command to delete images by temporary key
+    /// </summary>
+    public class DeleteImagesByTempKeyCommand : IRequest<ResultDto<bool>>
+    {
+        public string TempKey { get; set; } = string.Empty;
+        public bool Permanent { get; set; } = true;
+    }
 } 

--- a/backend/YemenBooking.Application/Commands/CP/Images/UploadImageCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Images/UploadImageCommand.cs
@@ -13,6 +13,12 @@ namespace YemenBooking.Application.Commands.Images
     public class UploadImageCommand : IRequest<ResultDto<ImageDto>>
     {
         /// <summary>
+        /// مفتاح مؤقت لربط الصور قبل إنشاء السجل المرتبط
+        /// Temporary key to associate images before entity/unit exists
+        /// </summary>
+        public string? TempKey { get; set; }
+
+        /// <summary>
         /// الملف المراد رفعه
         /// The file to upload
         /// </summary>

--- a/backend/YemenBooking.Application/Commands/CP/Properties/CreatePropertyCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Properties/CreatePropertyCommand.cs
@@ -10,6 +10,12 @@ namespace YemenBooking.Application.Commands.Properties;
 public class CreatePropertyCommand : IRequest<ResultDto<Guid>>
 {
     /// <summary>
+    /// مفتاح مؤقت للصور المرفوعة قبل الحفظ
+    /// Temporary key for pre-saved image uploads
+    /// </summary>
+    public string? TempKey { get; set; }
+
+    /// <summary>
     /// اسم الكيان
     /// Property name
     /// </summary>

--- a/backend/YemenBooking.Application/Commands/CP/Units/CreateUnitCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Units/CreateUnitCommand.cs
@@ -11,6 +11,12 @@ namespace YemenBooking.Application.Commands.Units;
 public class CreateUnitCommand : IRequest<ResultDto<Guid>>
 {
     /// <summary>
+    /// مفتاح مؤقت للصور المرفوعة قبل الحفظ
+    /// Temporary key for pre-saved image uploads
+    /// </summary>
+    public string? TempKey { get; set; }
+
+    /// <summary>
     /// معرف الكيان
     /// Property ID
     /// </summary>

--- a/backend/YemenBooking.Application/Handlers/Commands/Images/DeleteImagesCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Images/DeleteImagesCommandHandler.cs
@@ -7,6 +7,9 @@ using YemenBooking.Application.DTOs;
 using YemenBooking.Core.Interfaces.Repositories;
 using YemenBooking.Application.Interfaces.Services;
 using YemenBooking.Core.Interfaces;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using YemenBooking.Core.Entities;
 
 namespace YemenBooking.Application.Handlers.Commands.Images
 {
@@ -48,6 +51,48 @@ namespace YemenBooking.Application.Handlers.Commands.Images
             }, cancellationToken);
 
             return ResultDto<bool>.Ok(true, "تم حذف الصور المطلوبة بنجاح");
+        }
+    }
+
+    /// <summary>
+    /// معالج أمر حذف الصور وفق مفتاح مؤقت
+    /// </summary>
+    public class DeleteImagesByTempKeyCommandHandler : IRequestHandler<DeleteImagesByTempKeyCommand, ResultDto<bool>>
+    {
+        private readonly IPropertyImageRepository _imageRepository;
+        private readonly IFileStorageService _fileStorageService;
+        private readonly IUnitOfWork _unitOfWork;
+
+        public DeleteImagesByTempKeyCommandHandler(
+            IPropertyImageRepository imageRepository,
+            IFileStorageService fileStorageService,
+            IUnitOfWork unitOfWork)
+        {
+            _imageRepository = imageRepository;
+            _fileStorageService = fileStorageService;
+            _unitOfWork = unitOfWork;
+        }
+
+        public async Task<ResultDto<bool>> Handle(DeleteImagesByTempKeyCommand request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(request.TempKey))
+                return ResultDto<bool>.Failed("TempKey is required");
+
+            await _unitOfWork.ExecuteInTransactionAsync(async () =>
+            {
+                var query = _imageRepository.GetQueryable().Where(i => i.TempKey == request.TempKey);
+                var toDelete = await query.ToListAsync(cancellationToken);
+                foreach (var image in toDelete)
+                {
+                    var deleted = await _imageRepository.DeletePropertyImageAsync(image.Id, cancellationToken);
+                    if (deleted && request.Permanent && !string.IsNullOrEmpty(image.Url))
+                    {
+                        await _fileStorageService.DeleteFileAsync(image.Url, cancellationToken);
+                    }
+                }
+            }, cancellationToken);
+
+            return ResultDto<bool>.Ok(true, "تم حذف صور المفتاح المؤقت بنجاح");
         }
     }
 } 

--- a/backend/YemenBooking.Application/Handlers/Commands/Images/UploadImageCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Images/UploadImageCommandHandler.cs
@@ -69,7 +69,7 @@ namespace YemenBooking.Application.Handlers.Commands.Images
                 // تحويل المحتوى إلى تيار
                 var stream = new MemoryStream(request.File.FileContent);
 
-                // Determine dynamic folder path based on ImageType, PropertyId, and UnitId
+                // Determine dynamic folder path based on ImageType, PropertyId, UnitId or TempKey
                 Guid effectivePropertyId = request.PropertyId ?? Guid.Empty;
                 if (effectivePropertyId == Guid.Empty && request.UnitId.HasValue)
                 {
@@ -77,7 +77,11 @@ namespace YemenBooking.Application.Handlers.Commands.Images
                     effectivePropertyId = unitEntity?.PropertyId ?? Guid.Empty;
                 }
                 string folderPath;
-                if (effectivePropertyId == Guid.Empty)
+                if (!string.IsNullOrWhiteSpace(request.TempKey))
+                {
+                    folderPath = $"temp/{request.TempKey}";
+                }
+                else if (effectivePropertyId == Guid.Empty)
                 {
                     folderPath = "temp";
                 }
@@ -230,6 +234,7 @@ namespace YemenBooking.Application.Handlers.Commands.Images
                     Id = imageDto.Id,
                     PropertyId = propertyAssociation,
                     UnitId = request.UnitId,
+                    TempKey = string.IsNullOrWhiteSpace(request.TempKey) ? null : request.TempKey,
                     Name = fileName,
                     Url = uploadResult.FileUrl,
                     SizeBytes = uploadResult.FileSizeBytes,

--- a/backend/YemenBooking.Application/Handlers/Queries/Images/GetImagesQueryHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Queries/Images/GetImagesQueryHandler.cs
@@ -31,6 +31,9 @@ namespace YemenBooking.Application.Handlers.Queries.Images
             // 1. بناء الاستعلام مع الفلاتر
             var query = _imageRepository.GetQueryable().AsNoTracking();
 
+            if (!string.IsNullOrWhiteSpace(request.TempKey))
+                query = query.Where(i => i.TempKey == request.TempKey);
+
             if (request.PropertyId.HasValue && !request.UnitId.HasValue)
                 query = query.Where(i => i.PropertyId == request.PropertyId.Value);
             if (request.UnitId.HasValue)

--- a/backend/YemenBooking.Application/Queries/CP/Images/GetImagesQuery.cs
+++ b/backend/YemenBooking.Application/Queries/CP/Images/GetImagesQuery.cs
@@ -15,6 +15,12 @@ namespace YemenBooking.Application.Queries.Images
     public class GetImagesQuery : IRequest<ResultDto<PaginatedResultDto<ImageDto>>>
     {
         /// <summary>
+        /// مفتاح مؤقت لتجميع الصور قبل الربط
+        /// Temporary key to group images prior to binding
+        /// </summary>
+        public string? TempKey { get; set; }
+
+        /// <summary>
         /// معرف الكيان (اختياري)
         /// Property ID (optional)
         /// </summary>

--- a/backend/YemenBooking.Core/Entities/PropertyImage.cs
+++ b/backend/YemenBooking.Core/Entities/PropertyImage.cs
@@ -12,6 +12,13 @@ using YemenBooking.Core.Enums;
 public class PropertyImage : BaseEntity<Guid>
 {
     /// <summary>
+    /// مفتاح مؤقت لجلسة الرفع قبل إنشاء السجل المرتبط
+    /// Temporary key to group uploads before entity/unit is created
+    /// </summary>
+    [Display(Name = "المفتاح المؤقت")]
+    public string? TempKey { get; set; }
+
+    /// <summary>
     /// معرف الكيان (قابل للتمرير إلى NULL)
     /// Property identifier (nullable)
     /// </summary>

--- a/backend/YemenBooking.Core/Interfaces/Repositories/IPropertyImageRepository.cs
+++ b/backend/YemenBooking.Core/Interfaces/Repositories/IPropertyImageRepository.cs
@@ -102,4 +102,10 @@ public interface IPropertyImageRepository : IRepository<PropertyImage>
     /// Fetch images by their stored path values
     /// </summary>
     Task<IEnumerable<PropertyImage>> GetImagesByPathAsync(IEnumerable<string> paths, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// الحصول على صور بحسب المفتاح المؤقت
+    /// Get images by temporary key
+    /// </summary>
+    Task<IEnumerable<PropertyImage>> GetImagesByTempKeyAsync(string tempKey, CancellationToken cancellationToken = default);
 }

--- a/backend/YemenBooking.Infrastructure/Data/Configurations/PropertyImageConfiguration.cs
+++ b/backend/YemenBooking.Infrastructure/Data/Configurations/PropertyImageConfiguration.cs
@@ -29,6 +29,11 @@ public class PropertyImageConfiguration : IEntityTypeConfiguration<PropertyImage
             .HasMaxLength(500)
             .HasComment("مسار الصورة");
 
+        // TempKey column config
+        builder.Property(pi => pi.TempKey)
+            .HasMaxLength(100)
+            .HasComment("مفتاح مؤقت لرفع الصور قبل الربط");
+
         builder.Property(pi => pi.AltText)
             .HasMaxLength(500)
             .HasComment("وصف الصورة");
@@ -84,6 +89,7 @@ public class PropertyImageConfiguration : IEntityTypeConfiguration<PropertyImage
         // تكوين الفهرس
         builder.HasIndex(pi => pi.PropertyId);
         builder.HasIndex(pi => pi.UnitId);
+        builder.HasIndex(pi => pi.TempKey);
 
         builder.HasQueryFilter(pi => !pi.IsDeleted);
     }

--- a/backend/YemenBooking.Infrastructure/Migrations/20250903000000_AddTempKeyToPropertyImages.cs
+++ b/backend/YemenBooking.Infrastructure/Migrations/20250903000000_AddTempKeyToPropertyImages.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace YemenBooking.Infrastructure.Migrations
+{
+    public partial class AddTempKeyToPropertyImages : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TempKey",
+                table: "PropertyImages",
+                type: "NVARCHAR(100)",
+                nullable: true,
+                comment: "مفتاح مؤقت لرفع الصور قبل الربط");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PropertyImages_TempKey",
+                table: "PropertyImages",
+                column: "TempKey");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PropertyImages_TempKey",
+                table: "PropertyImages");
+
+            migrationBuilder.DropColumn(
+                name: "TempKey",
+                table: "PropertyImages");
+        }
+    }
+}

--- a/backend/YemenBooking.Infrastructure/Repositories/PropertyImageRepository.cs
+++ b/backend/YemenBooking.Infrastructure/Repositories/PropertyImageRepository.cs
@@ -181,4 +181,15 @@ public class PropertyImageRepository : BaseRepository<PropertyImage>, IPropertyI
             .Where(pi => paths.Contains(pi.Url))
             .ToListAsync(cancellationToken);
     }
+
+    /// <summary>
+    /// جلب صور حسب المفتاح المؤقت
+    /// </summary>
+    public async Task<IEnumerable<PropertyImage>> GetImagesByTempKeyAsync(string tempKey, CancellationToken cancellationToken = default)
+    {
+        return await _dbSet
+            .Where(pi => pi.TempKey == tempKey && !pi.IsDeleted)
+            .OrderBy(pi => pi.CreatedAt)
+            .ToListAsync(cancellationToken);
+    }
 }

--- a/control_panel_app/lib/features/admin_properties/data/datasources/property_images_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_properties/data/datasources/property_images_remote_datasource.dart
@@ -8,6 +8,7 @@ import '../models/property_image_model.dart';
 abstract class PropertyImagesRemoteDataSource {
   Future<PropertyImageModel> uploadImage({
     String? propertyId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -16,7 +17,7 @@ abstract class PropertyImagesRemoteDataSource {
     List<String>? tags,
   });
   
-  Future<List<PropertyImageModel>> getPropertyImages(String? propertyId);
+  Future<List<PropertyImageModel>> getPropertyImages(String? propertyId, {String? tempKey});
   Future<bool> updateImage(String imageId, Map<String, dynamic> data);
   Future<bool> deleteImage(String imageId);
   Future<bool> reorderImages(String? propertyId, List<String> imageIds);
@@ -32,6 +33,7 @@ class PropertyImagesRemoteDataSourceImpl implements PropertyImagesRemoteDataSour
   @override
   Future<PropertyImageModel> uploadImage({
     String? propertyId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -43,6 +45,7 @@ class PropertyImagesRemoteDataSourceImpl implements PropertyImagesRemoteDataSour
       final formData = FormData.fromMap({
         'file': await MultipartFile.fromFile(filePath),
         'propertyId': propertyId,
+        if (tempKey != null) 'tempKey': tempKey,
         if (category != null) 'category': category,
         if (alt != null) 'alt': alt,
         'isPrimary': isPrimary,
@@ -80,11 +83,11 @@ class PropertyImagesRemoteDataSourceImpl implements PropertyImagesRemoteDataSour
   }
   
   @override
-  Future<List<PropertyImageModel>> getPropertyImages(String? propertyId) async {
+  Future<List<PropertyImageModel>> getPropertyImages(String? propertyId, {String? tempKey}) async {
     try {
-      final response = await apiClient.get('$_imagesEndpoint', queryParameters: {
-        'propertyId': propertyId,
-      });
+      final qp = <String, dynamic>{'propertyId': propertyId};
+      if (tempKey != null) qp['tempKey'] = tempKey;
+      final response = await apiClient.get('$_imagesEndpoint', queryParameters: qp);
       
       if (response.data is Map<String, dynamic>) {
         final map = response.data as Map<String, dynamic>;

--- a/control_panel_app/lib/features/admin_properties/data/repositories/property_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_properties/data/repositories/property_images_repository_impl.dart
@@ -21,6 +21,7 @@ class PropertyImagesRepositoryImpl implements PropertyImagesRepository {
   @override
   Future<Either<Failure, PropertyImage>> uploadImage({
     String? propertyId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -32,6 +33,7 @@ class PropertyImagesRepositoryImpl implements PropertyImagesRepository {
       try {
         final PropertyImageModel result = await remoteDataSource.uploadImage(
           propertyId: propertyId,
+          tempKey: tempKey,
           filePath: filePath,
           category: category,
           alt: alt,
@@ -51,10 +53,10 @@ class PropertyImagesRepositoryImpl implements PropertyImagesRepository {
   }
 
   @override
-  Future<Either<Failure, List<PropertyImage>>> getPropertyImages(String? propertyId) async {
+  Future<Either<Failure, List<PropertyImage>>> getPropertyImages(String? propertyId, {String? tempKey}) async {
     if (await networkInfo.isConnected) {
       try {
-        final List<PropertyImageModel> result = await remoteDataSource.getPropertyImages(propertyId);
+        final List<PropertyImageModel> result = await remoteDataSource.getPropertyImages(propertyId, tempKey: tempKey);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));

--- a/control_panel_app/lib/features/admin_properties/domain/usecases/property_images/get_property_images_usecase.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/usecases/property_images/get_property_images_usecase.dart
@@ -6,13 +6,20 @@ import 'package:bookn_cp_app/core/usecases/usecase.dart';
 import '../../entities/property_image.dart';
 import '../../repositories/property_images_repository.dart';
 
-class GetPropertyImagesUseCase implements UseCase<List<PropertyImage>, String> {
+class GetPropertyImagesUseCase implements UseCase<List<PropertyImage>, GetImagesParams> {
   final PropertyImagesRepository repository;
 
   GetPropertyImagesUseCase(this.repository);
 
   @override
-  Future<Either<Failure, List<PropertyImage>>> call(String? propertyId) async {
-    return await repository.getPropertyImages(propertyId);
+  Future<Either<Failure, List<PropertyImage>>> call(GetImagesParams params) async {
+    return await repository.getPropertyImages(params.propertyId, tempKey: params.tempKey);
   }
+}
+
+class GetImagesParams {
+  final String? propertyId;
+  final String? tempKey;
+
+  GetImagesParams({this.propertyId, this.tempKey});
 }

--- a/control_panel_app/lib/features/admin_properties/domain/usecases/property_images/upload_property_image_usecase.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/usecases/property_images/upload_property_image_usecase.dart
@@ -15,6 +15,7 @@ class UploadPropertyImageUseCase implements UseCase<PropertyImage, UploadImagePa
   Future<Either<Failure, PropertyImage>> call(UploadImageParams params) async {
     return await repository.uploadImage(
       propertyId: params.propertyId,
+      tempKey: params.tempKey,
       filePath: params.filePath,
       category: params.category,
       alt: params.alt,
@@ -27,6 +28,7 @@ class UploadPropertyImageUseCase implements UseCase<PropertyImage, UploadImagePa
 
 class UploadImageParams {
   final String? propertyId;
+  final String? tempKey;
   final String filePath;
   final String? category;
   final String? alt;
@@ -36,6 +38,7 @@ class UploadImageParams {
 
   UploadImageParams({
     this.propertyId,
+    this.tempKey,
     required this.filePath,
     this.category,
     this.alt,

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/property_images/property_images_event.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/property_images/property_images_event.dart
@@ -11,15 +11,17 @@ abstract class PropertyImagesEvent extends Equatable {
 
 class LoadPropertyImagesEvent extends PropertyImagesEvent {
   final String? propertyId;
+  final String? tempKey;
 
-  const LoadPropertyImagesEvent({this.propertyId});
+  const LoadPropertyImagesEvent({this.propertyId, this.tempKey});
 
   @override
-  List<Object?> get props => [propertyId];
+  List<Object?> get props => [propertyId, tempKey];
 }
 
 class UploadPropertyImageEvent extends PropertyImagesEvent {
   final String? propertyId;
+  final String? tempKey;
   final String filePath;
   final String? category;
   final String? alt;
@@ -29,6 +31,7 @@ class UploadPropertyImageEvent extends PropertyImagesEvent {
 
   const UploadPropertyImageEvent({
     this.propertyId,
+    this.tempKey,
     required this.filePath,
     this.category,
     this.alt,
@@ -38,24 +41,26 @@ class UploadPropertyImageEvent extends PropertyImagesEvent {
   });
 
   @override
-  List<Object?> get props => [propertyId, filePath, category, alt, isPrimary, order, tags];
+  List<Object?> get props => [propertyId, tempKey, filePath, category, alt, isPrimary, order, tags];
 }
 
 class UploadMultipleImagesEvent extends PropertyImagesEvent {
   final String? propertyId;
+  final String? tempKey;
   final List<String> filePaths;
   final String? category;
   final List<String>? tags;
 
   const UploadMultipleImagesEvent({
     this.propertyId,
+    this.tempKey,
     required this.filePaths,
     this.category,
     this.tags,
   });
 
   @override
-  List<Object?> get props => [propertyId, filePaths, category, tags];
+  List<Object?> get props => [propertyId, tempKey, filePaths, category, tags];
 }
 
 class UpdatePropertyImageEvent extends PropertyImagesEvent {

--- a/control_panel_app/lib/features/admin_units/data/datasources/unit_images_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_units/data/datasources/unit_images_remote_datasource.dart
@@ -8,6 +8,7 @@ import '../models/unit_image_model.dart';
 abstract class UnitImagesRemoteDataSource {
   Future<UnitImageModel> uploadImage({
     String? unitId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -16,7 +17,7 @@ abstract class UnitImagesRemoteDataSource {
     List<String>? tags,
   });
   
-  Future<List<UnitImageModel>> getUnitImages(String? unitId);
+  Future<List<UnitImageModel>> getUnitImages(String? unitId, {String? tempKey});
   Future<bool> updateImage(String imageId, Map<String, dynamic> data);
   Future<bool> deleteImage(String imageId);
   Future<bool> reorderImages(String? unitId, List<String> imageIds);
@@ -32,6 +33,7 @@ class UnitImagesRemoteDataSourceImpl implements UnitImagesRemoteDataSource {
   @override
   Future<UnitImageModel> uploadImage({
     String? unitId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -43,6 +45,7 @@ class UnitImagesRemoteDataSourceImpl implements UnitImagesRemoteDataSource {
       final formData = FormData.fromMap({
         'file': await MultipartFile.fromFile(filePath),
         'unitId': unitId,
+        if (tempKey != null) 'tempKey': tempKey,
         if (category != null) 'category': category,
         if (alt != null) 'alt': alt,
         'isPrimary': isPrimary,
@@ -80,11 +83,11 @@ class UnitImagesRemoteDataSourceImpl implements UnitImagesRemoteDataSource {
   }
   
   @override
-  Future<List<UnitImageModel>> getUnitImages(String? unitId) async {
+  Future<List<UnitImageModel>> getUnitImages(String? unitId, {String? tempKey}) async {
     try {
-      final response = await apiClient.get('$_imagesEndpoint', queryParameters: {
-        'unitId': unitId,
-      });
+      final qp = <String, dynamic>{'unitId': unitId};
+      if (tempKey != null) qp['tempKey'] = tempKey;
+      final response = await apiClient.get('$_imagesEndpoint', queryParameters: qp);
       
       if (response.data is Map<String, dynamic>) {
         final map = response.data as Map<String, dynamic>;

--- a/control_panel_app/lib/features/admin_units/data/repositories/unit_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_units/data/repositories/unit_images_repository_impl.dart
@@ -21,6 +21,7 @@ class UnitImagesRepositoryImpl implements UnitImagesRepository {
   @override
   Future<Either<Failure, UnitImage>> uploadImage({
     String? unitId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -32,6 +33,7 @@ class UnitImagesRepositoryImpl implements UnitImagesRepository {
       try {
         final UnitImageModel result = await remoteDataSource.uploadImage(
           unitId: unitId,
+          tempKey: tempKey,
           filePath: filePath,
           category: category,
           alt: alt,
@@ -51,10 +53,10 @@ class UnitImagesRepositoryImpl implements UnitImagesRepository {
   }
 
   @override
-  Future<Either<Failure, List<UnitImage>>> getUnitImages(String? unitId) async {
+  Future<Either<Failure, List<UnitImage>>> getUnitImages(String? unitId, {String? tempKey}) async {
     if (await networkInfo.isConnected) {
       try {
-        final List<UnitImageModel> result = await remoteDataSource.getUnitImages(unitId);
+        final List<UnitImageModel> result = await remoteDataSource.getUnitImages(unitId, tempKey: tempKey);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));

--- a/control_panel_app/lib/features/admin_units/domain/usecases/unit_images/get_unit_images_usecase.dart
+++ b/control_panel_app/lib/features/admin_units/domain/usecases/unit_images/get_unit_images_usecase.dart
@@ -6,13 +6,20 @@ import 'package:bookn_cp_app/core/usecases/usecase.dart';
 import '../../entities/unit_image.dart';
 import '../../repositories/unit_images_repository.dart';
 
-class GetUnitImagesUseCase implements UseCase<List<UnitImage>, String> {
+class GetUnitImagesUseCase implements UseCase<List<UnitImage>, GetUnitImagesParams> {
   final UnitImagesRepository repository;
 
   GetUnitImagesUseCase(this.repository);
 
   @override
-  Future<Either<Failure, List<UnitImage>>> call(String? unitId) async {
-    return await repository.getUnitImages(unitId);
+  Future<Either<Failure, List<UnitImage>>> call(GetUnitImagesParams params) async {
+    return await repository.getUnitImages(params.unitId, tempKey: params.tempKey);
   }
+}
+
+class GetUnitImagesParams {
+  final String? unitId;
+  final String? tempKey;
+
+  GetUnitImagesParams({this.unitId, this.tempKey});
 }

--- a/control_panel_app/lib/features/admin_units/domain/usecases/unit_images/upload_unit_image_usecase.dart
+++ b/control_panel_app/lib/features/admin_units/domain/usecases/unit_images/upload_unit_image_usecase.dart
@@ -15,6 +15,7 @@ class UploadUnitImageUseCase implements UseCase<UnitImage, UploadImageParams> {
   Future<Either<Failure, UnitImage>> call(UploadImageParams params) async {
     return await repository.uploadImage(
       unitId: params.unitId,
+      tempKey: params.tempKey,
       filePath: params.filePath,
       category: params.category,
       alt: params.alt,
@@ -27,6 +28,7 @@ class UploadUnitImageUseCase implements UseCase<UnitImage, UploadImageParams> {
 
 class UploadImageParams {
   final String? unitId;
+  final String? tempKey;
   final String filePath;
   final String? category;
   final String? alt;
@@ -36,6 +38,7 @@ class UploadImageParams {
 
   UploadImageParams({
     this.unitId,
+    this.tempKey,
     required this.filePath,
     this.category,
     this.alt,

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_bloc.dart
@@ -59,8 +59,8 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
     LoadUnitImagesEvent event,
     Emitter<UnitImagesState> emit,
   ) async {
-    // منع جلب الصور إذا لم يكن هناك unitId
-    if (event.unitId == null || event.unitId!.isEmpty) {
+    // منع جلب الصور إذا لم يكن هناك unitId أو tempKey
+    if ((event.unitId == null || event.unitId!.isEmpty) && (event.tempKey == null || event.tempKey!.isEmpty)) {
       emit(const UnitImagesLoaded(images: []));
       return;
     }
@@ -68,7 +68,7 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
     emit(const UnitImagesLoading(message: 'Loading images...'));
 
     final Either<Failure, List<UnitImage>> result =
-        await getUnitImages(event.unitId!);
+        await getUnitImages(GetUnitImagesParams(unitId: event.unitId, tempKey: event.tempKey));
 
     result.fold(
       (failure) => emit(UnitImagesError(
@@ -90,10 +90,10 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
     UploadUnitImageEvent event,
     Emitter<UnitImagesState> emit,
   ) async {
-    // تحقق من وجود unitId قبل الرفع
-    if (event.unitId == null || event.unitId!.isEmpty) {
+    // تحقق من وجود unitId أو tempKey قبل الرفع
+    if ((event.unitId == null || event.unitId!.isEmpty) && (event.tempKey == null || event.tempKey!.isEmpty)) {
       emit(UnitImagesError(
-        message: 'لا يمكن رفع الصور بدون معرف الوحدة',
+        message: 'لا يمكن رفع الصور بدون معرف الوحدة أو tempKey',
         previousImages: _currentImages,
       ));
       return;
@@ -106,6 +106,7 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
 
     final params = UploadImageParams(
       unitId: event.unitId,
+      tempKey: event.tempKey,
       filePath: event.filePath,
       category: event.category,
       alt: event.alt,
@@ -170,7 +171,7 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
         ));
         // بعد ثانية واحدة، عرض قائمة الصور المحدثة
         Future.delayed(const Duration(seconds: 1), () {
-          add(LoadUnitImagesEvent(unitId: event.unitId));
+          add(LoadUnitImagesEvent(unitId: event.unitId, tempKey: event.tempKey));
         });
       },
     );

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_event.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_event.dart
@@ -11,15 +11,17 @@ abstract class UnitImagesEvent extends Equatable {
 
 class LoadUnitImagesEvent extends UnitImagesEvent {
   final String? unitId;
+  final String? tempKey;
 
-  const LoadUnitImagesEvent({this.unitId});
+  const LoadUnitImagesEvent({this.unitId, this.tempKey});
 
   @override
-  List<Object?> get props => [unitId];
+  List<Object?> get props => [unitId, tempKey];
 }
 
 class UploadUnitImageEvent extends UnitImagesEvent {
   final String? unitId;
+  final String? tempKey;
   final String filePath;
   final String? category;
   final String? alt;
@@ -29,6 +31,7 @@ class UploadUnitImageEvent extends UnitImagesEvent {
 
   const UploadUnitImageEvent({
     this.unitId,
+    this.tempKey,
     required this.filePath,
     this.category,
     this.alt,
@@ -38,24 +41,26 @@ class UploadUnitImageEvent extends UnitImagesEvent {
   });
 
   @override
-  List<Object?> get props => [unitId, filePath, category, alt, isPrimary, order, tags];
+  List<Object?> get props => [unitId, tempKey, filePath, category, alt, isPrimary, order, tags];
 }
 
 class UploadMultipleUnitImagesEvent extends UnitImagesEvent {
   final String? unitId;
+  final String? tempKey;
   final List<String> filePaths;
   final String? category;
   final List<String>? tags;
 
   const UploadMultipleUnitImagesEvent({
     this.unitId,
+    this.tempKey,
     required this.filePaths,
     this.category,
     this.tags,
   });
 
   @override
-  List<Object?> get props => [unitId, filePaths, category, tags];
+  List<Object?> get props => [unitId, tempKey, filePaths, category, tags];
 }
 
 class UpdateUnitImageEvent extends UnitImagesEvent {

--- a/control_panel_app/lib/features/admin_units/presentation/widgets/unit_image_gallery.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/widgets/unit_image_gallery.dart
@@ -21,6 +21,7 @@ import '../bloc/unit_images/unit_images_state.dart';
 
 class UnitImageGallery extends StatefulWidget {
   final String? unitId;
+  final String? tempKey;
   final bool isReadOnly;
   final int maxImages;
   final Function(List<UnitImage>)? onImagesChanged;
@@ -31,6 +32,7 @@ class UnitImageGallery extends StatefulWidget {
   const UnitImageGallery({
     super.key,
     this.unitId,
+    this.tempKey,
     this.isReadOnly = false,
     this.maxImages = 10,
     this.onImagesChanged,
@@ -69,7 +71,7 @@ class UnitImageGalleryState extends State<UnitImageGallery>
   int? _primaryImageIndex = 0;
   
   // تحديد الوضع المحلي بناءً على وجود unitId
-  bool get _isLocalMode => widget.unitId == null || widget.unitId!.isEmpty;
+  bool get _isLocalMode => (widget.unitId == null || widget.unitId!.isEmpty) && (widget.tempKey == null || widget.tempKey!.isEmpty);
   bool _isInitialLoadDone = false;
   
   @override
@@ -113,8 +115,8 @@ class UnitImageGalleryState extends State<UnitImageGallery>
     if (!_isLocalMode && !_isInitialLoadDone) {
       try {
         _imagesBloc = context.read<UnitImagesBloc?>();
-        if (_imagesBloc != null && widget.unitId != null && widget.unitId!.isNotEmpty) {
-          _imagesBloc!.add(LoadUnitImagesEvent(unitId: widget.unitId!));
+        if (_imagesBloc != null && ((widget.unitId != null && widget.unitId!.isNotEmpty) || (widget.tempKey != null && widget.tempKey!.isNotEmpty))) {
+          _imagesBloc!.add(LoadUnitImagesEvent(unitId: widget.unitId, tempKey: widget.tempKey));
           _isInitialLoadDone = true;
         }
       } catch (e) {
@@ -489,7 +491,8 @@ class UnitImageGalleryState extends State<UnitImageGallery>
             _uploadingFiles.add(image.path);
           });
           _imagesBloc!.add(UploadUnitImageEvent(
-            unitId: widget.unitId!,
+            unitId: widget.unitId,
+            tempKey: widget.tempKey,
             filePath: image.path,
             isPrimary: _displayImages.isEmpty,
           ));
@@ -528,7 +531,8 @@ class UnitImageGalleryState extends State<UnitImageGallery>
               }
             });
             _imagesBloc!.add(UploadMultipleUnitImagesEvent(
-              unitId: widget.unitId!,
+              unitId: widget.unitId,
+              tempKey: widget.tempKey,
               filePaths: imagesToAdd.map((img) => img.path).toList(),
             ));
           }


### PR DESCRIPTION
Enable immediate image uploads during property and unit creation by introducing a temporary key mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-281680b2-6d35-4c0e-9fa3-cc596f5cbda6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-281680b2-6d35-4c0e-9fa3-cc596f5cbda6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

