### PR TITLE
Implement temp key for immediate image uploads during creation

### DIFF
--- a/control_panel_app/lib/features/admin_properties/data/repositories/property_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_properties/data/repositories/property_images_repository_impl.dart
@@ -167,6 +167,7 @@ class PropertyImagesRepositoryImpl implements PropertyImagesRepository {
   @override
   Future<Either<Failure, List<PropertyImage>>> uploadMultipleImages({
     String? propertyId,
+    String? tempKey,
     required List<String> filePaths,
     String? category,
     List<String>? tags,
@@ -180,6 +181,7 @@ class PropertyImagesRepositoryImpl implements PropertyImagesRepository {
           try {
             final result = await remoteDataSource.uploadImage(
               propertyId: propertyId,
+              tempKey: tempKey,
               filePath: filePath,
               category: category,
               isPrimary: order == 0, // الصورة الأولى تكون رئيسية

--- a/control_panel_app/lib/features/admin_properties/domain/repositories/property_images_repository.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/repositories/property_images_repository.dart
@@ -7,6 +7,7 @@ import 'package:bookn_cp_app/core/error/failures.dart';
 abstract class PropertyImagesRepository {
   Future<Either<Failure, PropertyImage>> uploadImage({
     String? propertyId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -15,7 +16,7 @@ abstract class PropertyImagesRepository {
     List<String>? tags,
   });
   
-  Future<Either<Failure, List<PropertyImage>>> getPropertyImages(String? propertyId);
+  Future<Either<Failure, List<PropertyImage>>> getPropertyImages(String? propertyId, {String? tempKey});
   
   Future<Either<Failure, bool>> updateImage(
     String imageId,
@@ -38,6 +39,7 @@ abstract class PropertyImagesRepository {
   
   Future<Either<Failure, List<PropertyImage>>> uploadMultipleImages({
     String? propertyId,
+    String? tempKey,
     required List<String> filePaths,
     String? category,
     List<String>? tags,

--- a/control_panel_app/lib/features/admin_properties/domain/usecases/properties/create_property_usecase.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/usecases/properties/create_property_usecase.dart
@@ -17,6 +17,7 @@ class CreatePropertyParams {
   final int starRating;
   final List<String>? images;
   final List<String>? amenityIds; // أضف هذا السطر
+  final String? tempKey;
   
   CreatePropertyParams({
     required this.name,
@@ -30,6 +31,7 @@ class CreatePropertyParams {
     required this.starRating,
     this.images,
     this.amenityIds, // أضف هذا السطر
+    this.tempKey,
   });
   
   Map<String, dynamic> toJson() {
@@ -45,6 +47,7 @@ class CreatePropertyParams {
     'starRating': starRating,
       if (images != null && images!.isNotEmpty) 'images': images,
       if (amenityIds != null && amenityIds!.isNotEmpty) 'amenityIds': amenityIds,
+      if (tempKey != null && tempKey!.isNotEmpty) 'tempKey': tempKey,
     };
   }
 }

--- a/control_panel_app/lib/features/admin_properties/domain/usecases/property_images/upload_multiple_images_usecase.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/usecases/property_images/upload_multiple_images_usecase.dart
@@ -15,6 +15,7 @@ class UploadMultipleImagesUseCase implements UseCase<List<PropertyImage>, Upload
   Future<Either<Failure, List<PropertyImage>>> call(UploadMultipleImagesParams params) async {
     return await repository.uploadMultipleImages(
       propertyId: params.propertyId,
+      tempKey: params.tempKey,
       filePaths: params.filePaths,
       category: params.category,
       tags: params.tags,
@@ -24,12 +25,14 @@ class UploadMultipleImagesUseCase implements UseCase<List<PropertyImage>, Upload
 
 class UploadMultipleImagesParams {
   final String? propertyId;
+  final String? tempKey;
   final List<String> filePaths;
   final String? category;
   final List<String>? tags;
 
   UploadMultipleImagesParams({
     this.propertyId,
+    this.tempKey,
     required this.filePaths,
     this.category,
     this.tags,

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_bloc.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_bloc.dart
@@ -112,6 +112,7 @@ class PropertiesBloc extends Bloc<PropertiesEvent, PropertiesState> {
         starRating: event.starRating,
         images: event.images,
         amenityIds: event.amenityIds,
+        tempKey: event.tempKey,
       ),
     );
     

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_event.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_event.dart
@@ -54,6 +54,7 @@ class CreatePropertyEvent extends PropertiesEvent {
   final int starRating;
   final List<String>? images;
   final List<String>? amenityIds;
+  final String? tempKey;
   
   const CreatePropertyEvent({
     required this.name,
@@ -67,6 +68,7 @@ class CreatePropertyEvent extends PropertiesEvent {
     required this.starRating,
     this.images,
     this.amenityIds, 
+    this.tempKey,
     required String shortDescription, 
     required double basePricePerNight, 
     required String currency, 
@@ -76,7 +78,7 @@ class CreatePropertyEvent extends PropertiesEvent {
   @override
   List<Object?> get props => [
     name, address, propertyTypeId, ownerId, description,
-    latitude, longitude, city, starRating, images, amenityIds,
+    latitude, longitude, city, starRating, images, amenityIds, tempKey,
   ];
 }
 

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/property_images/property_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/property_images/property_images_bloc.dart
@@ -147,6 +147,7 @@ class PropertyImagesBloc extends Bloc<PropertyImagesEvent, PropertyImagesState> 
     
     final params = UploadMultipleImagesParams(
       propertyId: event.propertyId,
+      tempKey: event.tempKey,
       filePaths: event.filePaths,
       category: event.category,
       tags: event.tags,

--- a/control_panel_app/lib/features/admin_properties/presentation/widgets/property_image_gallery.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/widgets/property_image_gallery.dart
@@ -1749,6 +1749,7 @@ class PropertyImageGalleryState extends State<PropertyImageGallery>
           });
           _imagesBloc!.add(UploadMultipleImagesEvent(
             propertyId: widget.propertyId!,
+            tempKey: widget.tempKey,
             filePaths: filesToAdd.map((file) => file.path).toList(),
           ));
         }

--- a/control_panel_app/lib/features/admin_units/data/repositories/unit_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_units/data/repositories/unit_images_repository_impl.dart
@@ -167,6 +167,7 @@ class UnitImagesRepositoryImpl implements UnitImagesRepository {
   @override
   Future<Either<Failure, List<UnitImage>>> uploadMultipleImages({
     String? unitId,
+    String? tempKey,
     required List<String> filePaths,
     String? category,
     List<String>? tags,
@@ -180,6 +181,7 @@ class UnitImagesRepositoryImpl implements UnitImagesRepository {
           try {
             final result = await remoteDataSource.uploadImage(
               unitId: unitId,
+              tempKey: tempKey,
               filePath: filePath,
               category: category,
               isPrimary: order == 0, // الصورة الأولى تكون رئيسية

--- a/control_panel_app/lib/features/admin_units/data/repositories/units_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_units/data/repositories/units_repository_impl.dart
@@ -98,6 +98,7 @@ class UnitsRepositoryImpl implements UnitsRepository {
     List<String>? images,
     int? adultCapacity,
     int? childrenCapacity,
+    String? tempKey,
   }) async {
     if (await networkInfo.isConnected) {
       try {
@@ -112,6 +113,7 @@ class UnitsRepositoryImpl implements UnitsRepository {
           'images': images,
           'adultCapacity': adultCapacity,
           'childrenCapacity': childrenCapacity,
+          if (tempKey != null && tempKey.isNotEmpty) 'tempKey': tempKey,
         };
         final unitId = await remoteDataSource.createUnit(unitData);
         return Right(unitId);

--- a/control_panel_app/lib/features/admin_units/domain/repositories/unit_images_repository.dart
+++ b/control_panel_app/lib/features/admin_units/domain/repositories/unit_images_repository.dart
@@ -7,6 +7,7 @@ import 'package:bookn_cp_app/core/error/failures.dart';
 abstract class UnitImagesRepository {
   Future<Either<Failure, UnitImage>> uploadImage({
     String? unitId,
+    String? tempKey,
     required String filePath,
     String? category,
     String? alt,
@@ -15,7 +16,7 @@ abstract class UnitImagesRepository {
     List<String>? tags,
   });
   
-  Future<Either<Failure, List<UnitImage>>> getUnitImages(String? unitId);
+  Future<Either<Failure, List<UnitImage>>> getUnitImages(String? unitId, {String? tempKey});
   
   Future<Either<Failure, bool>> updateImage(
     String imageId,
@@ -38,6 +39,7 @@ abstract class UnitImagesRepository {
   
   Future<Either<Failure, List<UnitImage>>> uploadMultipleImages({
     String? unitId,
+    String? tempKey,
     required List<String> filePaths,
     String? category,
     List<String>? tags,

--- a/control_panel_app/lib/features/admin_units/domain/repositories/units_repository.dart
+++ b/control_panel_app/lib/features/admin_units/domain/repositories/units_repository.dart
@@ -29,6 +29,7 @@ abstract class UnitsRepository {
     List<String>? images,
     int? adultCapacity,
     int? childrenCapacity,
+    String? tempKey,
   });
 
   Future<Either<Failure, bool>> updateUnit({

--- a/control_panel_app/lib/features/admin_units/domain/usecases/create_unit_usecase.dart
+++ b/control_panel_app/lib/features/admin_units/domain/usecases/create_unit_usecase.dart
@@ -22,6 +22,7 @@ class CreateUnitUseCase implements UseCase<String, CreateUnitParams> {
       images: params.images,
       adultCapacity: params.adultCapacity,
       childrenCapacity: params.childrenCapacity,
+      tempKey: params.tempKey,
     );
   }
 }
@@ -38,6 +39,7 @@ class CreateUnitParams extends Equatable {
   final List<String>? images;
   final int? adultCapacity;
   final int? childrenCapacity;
+  final String? tempKey;
 
   const CreateUnitParams({
     required this.propertyId,
@@ -51,6 +53,7 @@ class CreateUnitParams extends Equatable {
     this.images,
     this.adultCapacity,
     this.childrenCapacity,
+    this.tempKey,
   });
 
   // إضافة toJson للـ debugging
@@ -66,6 +69,7 @@ class CreateUnitParams extends Equatable {
     'images': images,
     'adultCapacity': adultCapacity,
     'childrenCapacity': childrenCapacity,
+    'tempKey': tempKey,
   };
 
   @override
@@ -81,5 +85,6 @@ class CreateUnitParams extends Equatable {
     images,
     adultCapacity,
     childrenCapacity,
+    tempKey,
   ];
 }

--- a/control_panel_app/lib/features/admin_units/domain/usecases/unit_images/upload_multiple_unit_images_usecase.dart
+++ b/control_panel_app/lib/features/admin_units/domain/usecases/unit_images/upload_multiple_unit_images_usecase.dart
@@ -15,6 +15,7 @@ class UploadMultipleUnitImagesUseCase implements UseCase<List<UnitImage>, Upload
   Future<Either<Failure, List<UnitImage>>> call(UploadMultipleImagesParams params) async {
     return await repository.uploadMultipleImages(
       unitId: params.unitId,
+      tempKey: params.tempKey,
       filePaths: params.filePaths,
       category: params.category,
       tags: params.tags,
@@ -24,12 +25,14 @@ class UploadMultipleUnitImagesUseCase implements UseCase<List<UnitImage>, Upload
 
 class UploadMultipleImagesParams {
   final String? unitId;
+  final String? tempKey;
   final List<String> filePaths;
   final String? category;
   final List<String>? tags;
 
   UploadMultipleImagesParams({
     this.unitId,
+    this.tempKey,
     required this.filePaths,
     this.category,
     this.tags,

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_form/unit_form_bloc.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_form/unit_form_bloc.dart
@@ -49,7 +49,7 @@ class UnitFormBloc extends Bloc<UnitFormEvent, UnitFormState> {
         unitId: event.unitId,
       ));
     } else {
-      emit(const UnitFormReady());
+      emit(UnitFormReady(tempKey: event.tempKey));
     }
   }
 
@@ -225,6 +225,7 @@ class UnitFormBloc extends Bloc<UnitFormEvent, UnitFormState> {
           images: currentState.images,
           adultCapacity: currentState.adultCapacity ?? 0,
           childrenCapacity: currentState.childrenCapacity ?? 0,
+          tempKey: currentState.tempKey,
         ));
         
         result.fold(

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_form/unit_form_event.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_form/unit_form_event.dart
@@ -9,11 +9,12 @@ abstract class UnitFormEvent extends Equatable {
 
 class InitializeFormEvent extends UnitFormEvent {
   final String? unitId;
+  final String? tempKey;
 
-  const InitializeFormEvent({this.unitId});
+  const InitializeFormEvent({this.unitId, this.tempKey});
 
   @override
-  List<Object?> get props => [unitId];
+  List<Object?> get props => [unitId, tempKey];
 }
 
 class PropertySelectedEvent extends UnitFormEvent {

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_form/unit_form_state.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_form/unit_form_state.dart
@@ -15,6 +15,7 @@ class UnitFormReady extends UnitFormState {
   final bool isEditMode;
   final String? unitId;
   final String? selectedPropertyId;
+  final String? tempKey;
   final List<UnitType> availableUnitTypes;
   final UnitType? selectedUnitType;
   final List<UnitTypeField> unitTypeFields;
@@ -34,6 +35,7 @@ class UnitFormReady extends UnitFormState {
     this.isEditMode = false,
     this.unitId,
     this.selectedPropertyId,
+    this.tempKey,
     this.availableUnitTypes = const [],
     this.selectedUnitType,
     this.unitTypeFields = const [],
@@ -54,6 +56,7 @@ class UnitFormReady extends UnitFormState {
     bool? isEditMode,
     String? unitId,
     String? selectedPropertyId,
+    String? tempKey,
     List<UnitType>? availableUnitTypes,
     UnitType? selectedUnitType,
     List<UnitTypeField>? unitTypeFields,
@@ -73,6 +76,7 @@ class UnitFormReady extends UnitFormState {
       isEditMode: isEditMode ?? this.isEditMode,
       unitId: unitId ?? this.unitId,
       selectedPropertyId: selectedPropertyId ?? this.selectedPropertyId,
+      tempKey: tempKey ?? this.tempKey,
       availableUnitTypes: availableUnitTypes ?? this.availableUnitTypes,
       selectedUnitType: selectedUnitType ?? this.selectedUnitType,
       unitTypeFields: unitTypeFields ?? this.unitTypeFields,
@@ -95,6 +99,7 @@ class UnitFormReady extends UnitFormState {
         isEditMode,
         unitId,
         selectedPropertyId,
+        tempKey,
         availableUnitTypes,
         selectedUnitType,
         unitTypeFields,

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_bloc.dart
@@ -148,6 +148,7 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
 
     final params = UploadMultipleImagesParams(
       unitId: event.unitId,
+      tempKey: event.tempKey,
       filePaths: event.filePaths,
       category: event.category,
       tags: event.tags,

--- a/control_panel_app/lib/features/admin_units/presentation/widgets/unit_image_gallery.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/widgets/unit_image_gallery.dart
@@ -485,7 +485,7 @@ class UnitImageGalleryState extends State<UnitImageGallery>
             widget.onLocalImagesChanged!(_localImages);
           }
           _showSuccessSnackBar('تم إضافة الصورة (سيتم الرفع عند الحفظ)');
-        } else if (_imagesBloc != null && widget.unitId != null) {
+        } else if (_imagesBloc != null && (widget.unitId != null || (widget.tempKey != null && widget.tempKey!.isNotEmpty))) {
           // في وضع التعديل، ارفع مباشرة
           setState(() {
             _uploadingFiles.add(image.path);
@@ -1748,7 +1748,8 @@ class UnitImageGalleryState extends State<UnitImageGallery>
             }
           });
           _imagesBloc!.add(UploadMultipleUnitImagesEvent(
-            unitId: widget.unitId!,
+            unitId: widget.unitId,
+            tempKey: widget.tempKey,
             filePaths: filesToAdd.map((file) => file.path).toList(),
           ));
         }


### PR DESCRIPTION
Enable pre-save image uploads for property and unit creation using a temporary key (tempKey) and ensure cleanup of unused images.

Previously, images for new properties/units could only be uploaded after the entity was saved. This PR introduces a `tempKey` to allow immediate image uploads during creation, providing a consistent user experience with the update flow. Images are initially linked to the `tempKey` and then bound to the final property/unit ID upon successful save. If the creation is abandoned, the temporary images are automatically purged.

---
<a href="https://cursor.com/background-agent?bcId=bc-564019bc-ec42-4e9e-8eed-7c7110cc37ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-564019bc-ec42-4e9e-8eed-7c7110cc37ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

