### PR TITLE
Fix invalid request on unit gallery navigation

### DIFF
--- a/control_panel_app/lib/features/admin_units/presentation/pages/unit_details_page.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/pages/unit_details_page.dart
@@ -1483,7 +1483,7 @@ class _UnitDetailsPageState extends State<UnitDetailsPage>
     final state = context.read<UnitDetailsBloc>().state;
     if (state is UnitDetailsLoaded) {
       context.go(
-        '/admin/units/$widget.unitId/gallery',
+        '/admin/units/${widget.unitId}/gallery',
         extra: state.unit,
       );
     }

--- a/control_panel_app/lib/features/admin_units/presentation/pages/unit_details_page.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/pages/unit_details_page.dart
@@ -1482,7 +1482,7 @@ class _UnitDetailsPageState extends State<UnitDetailsPage>
   void _navigateToGallery() {
     final state = context.read<UnitDetailsBloc>().state;
     if (state is UnitDetailsLoaded) {
-      context.go(
+      context.push(
         '/admin/units/${widget.unitId}/gallery',
         extra: state.unit,
       );


### PR DESCRIPTION
Fix 'Bad Request' error when navigating to unit gallery by correcting route string interpolation.

The `unitId` was incorrectly interpolated as `$widget.unitId` instead of `${widget.unitId}` in the gallery route path, which resulted in an invalid ID being sent in the URL and caused a 400 API response.

---
<a href="https://cursor.com/background-agent?bcId=bc-42e86d0e-bd57-42c2-9bea-ed8ebc33c108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42e86d0e-bd57-42c2-9bea-ed8ebc33c108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

