### PR TITLE
Fix dialog background color to match main page

### DIFF
--- a/control_panel_app/lib/features/admin_amenities/presentation/widgets/amenity_form_dialog.dart
+++ b/control_panel_app/lib/features/admin_amenities/presentation/widgets/amenity_form_dialog.dart
@@ -101,12 +101,12 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
               ),
               borderRadius: BorderRadius.circular(24),
               border: Border.all(
-                color: AppTheme.primaryPurple.withOpacity(0.3),
+                color: AppTheme.primaryBlue.withOpacity(0.3),
                 width: 1.5,
               ),
               boxShadow: [
                 BoxShadow(
-                  color: AppTheme.primaryPurple.withOpacity(0.2),
+                  color: AppTheme.primaryBlue.withOpacity(0.2),
                   blurRadius: 30,
                   spreadRadius: 5,
                 ),
@@ -165,7 +165,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
         ),
         border: Border(
           bottom: BorderSide(
-            color: AppTheme.primaryPurple.withOpacity(0.2),
+            color: AppTheme.primaryBlue.withOpacity(0.2),
             width: 1,
           ),
         ),
@@ -180,7 +180,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
               borderRadius: BorderRadius.circular(12),
               boxShadow: [
                 BoxShadow(
-                  color: AppTheme.primaryPurple.withOpacity(0.3),
+                  color: AppTheme.primaryBlue.withOpacity(0.3),
                   blurRadius: 15,
                   spreadRadius: 2,
                 ),
@@ -264,7 +264,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryPurple.withOpacity(0.3),
+                color: AppTheme.primaryBlue.withOpacity(0.3),
               ),
             ),
             enabledBorder: OutlineInputBorder(
@@ -276,7 +276,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryPurple.withOpacity(0.5),
+                color: AppTheme.primaryBlue.withOpacity(0.5),
                 width: 2,
               ),
             ),
@@ -288,7 +288,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             ),
             prefixIcon: Icon(
               Icons.label_rounded,
-              color: AppTheme.primaryPurple.withOpacity(0.7),
+              color: AppTheme.primaryBlue.withOpacity(0.7),
             ),
           ),
           validator: (value) {
@@ -328,7 +328,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryPurple.withOpacity(0.3),
+                color: AppTheme.primaryBlue.withOpacity(0.3),
               ),
             ),
             enabledBorder: OutlineInputBorder(
@@ -340,7 +340,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryPurple.withOpacity(0.5),
+                color: AppTheme.primaryBlue.withOpacity(0.5),
                 width: 2,
               ),
             ),
@@ -354,7 +354,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
               padding: const EdgeInsets.only(bottom: 40),
               child: Icon(
                 Icons.description_rounded,
-                color: AppTheme.primaryPurple.withOpacity(0.7),
+                color: AppTheme.primaryBlue.withOpacity(0.7),
               ),
             ),
           ),
@@ -723,7 +723,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
         ),
         border: Border(
           top: BorderSide(
-            color: AppTheme.primaryPurple.withOpacity(0.2),
+            color: AppTheme.primaryBlue.withOpacity(0.2),
             width: 1,
           ),
         ),

--- a/control_panel_app/lib/features/admin_amenities/presentation/widgets/amenity_form_dialog.dart
+++ b/control_panel_app/lib/features/admin_amenities/presentation/widgets/amenity_form_dialog.dart
@@ -101,12 +101,12 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
               ),
               borderRadius: BorderRadius.circular(24),
               border: Border.all(
-                color: AppTheme.primaryBlue.withOpacity(0.3),
+                color: AppTheme.primaryPurple.withOpacity(0.3),
                 width: 1.5,
               ),
               boxShadow: [
                 BoxShadow(
-                  color: AppTheme.primaryBlue.withOpacity(0.2),
+                  color: AppTheme.primaryPurple.withOpacity(0.2),
                   blurRadius: 30,
                   spreadRadius: 5,
                 ),
@@ -165,7 +165,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
         ),
         border: Border(
           bottom: BorderSide(
-            color: AppTheme.primaryBlue.withOpacity(0.2),
+            color: AppTheme.primaryPurple.withOpacity(0.2),
             width: 1,
           ),
         ),
@@ -180,7 +180,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
               borderRadius: BorderRadius.circular(12),
               boxShadow: [
                 BoxShadow(
-                  color: AppTheme.primaryBlue.withOpacity(0.3),
+                  color: AppTheme.primaryPurple.withOpacity(0.3),
                   blurRadius: 15,
                   spreadRadius: 2,
                 ),
@@ -264,7 +264,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryBlue.withOpacity(0.3),
+                color: AppTheme.primaryPurple.withOpacity(0.3),
               ),
             ),
             enabledBorder: OutlineInputBorder(
@@ -276,7 +276,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryBlue.withOpacity(0.5),
+                color: AppTheme.primaryPurple.withOpacity(0.5),
                 width: 2,
               ),
             ),
@@ -288,7 +288,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             ),
             prefixIcon: Icon(
               Icons.label_rounded,
-              color: AppTheme.primaryBlue.withOpacity(0.7),
+              color: AppTheme.primaryPurple.withOpacity(0.7),
             ),
           ),
           validator: (value) {
@@ -328,7 +328,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             border: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryBlue.withOpacity(0.3),
+                color: AppTheme.primaryPurple.withOpacity(0.3),
               ),
             ),
             enabledBorder: OutlineInputBorder(
@@ -340,7 +340,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
             focusedBorder: OutlineInputBorder(
               borderRadius: BorderRadius.circular(12),
               borderSide: BorderSide(
-                color: AppTheme.primaryBlue.withOpacity(0.5),
+                color: AppTheme.primaryPurple.withOpacity(0.5),
                 width: 2,
               ),
             ),
@@ -354,7 +354,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
               padding: const EdgeInsets.only(bottom: 40),
               child: Icon(
                 Icons.description_rounded,
-                color: AppTheme.primaryBlue.withOpacity(0.7),
+                color: AppTheme.primaryPurple.withOpacity(0.7),
               ),
             ),
           ),
@@ -723,7 +723,7 @@ class _AmenityFormDialogState extends State<AmenityFormDialog>
         ),
         border: Border(
           top: BorderSide(
-            color: AppTheme.primaryBlue.withOpacity(0.2),
+            color: AppTheme.primaryPurple.withOpacity(0.2),
             width: 1,
           ),
         ),

--- a/control_panel_app/lib/features/admin_amenities/presentation/widgets/assign_amenity_dialog.dart
+++ b/control_panel_app/lib/features/admin_amenities/presentation/widgets/assign_amenity_dialog.dart
@@ -210,8 +210,9 @@ class _AssignAmenityDialogState extends State<AssignAmenityDialog>
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  AppTheme.darkCard.withOpacity(0.95),
-                  const Color(0xFF1A0E2E).withOpacity(0.8),
+                  AppTheme.darkBackground,
+                  AppTheme.darkBackground2.withOpacity(0.8),
+                  AppTheme.darkBackground3.withOpacity(0.6),
                 ],
               ),
               borderRadius: BorderRadius.circular(24), // زوايا حادة هادئة


### PR DESCRIPTION
Update `AssignAmenityDialog` background gradient to match `AmenitiesManagementPage` for consistent UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-f18086b2-fd2b-4df7-ae5d-d0ed2213c565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f18086b2-fd2b-4df7-ae5d-d0ed2213c565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

