### PR TITLE
Fix renderflex overflow on admin hub page

### DIFF
--- a/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
+++ b/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
@@ -1008,7 +1008,7 @@ class _AdminHubPageState extends State<AdminHubPage>
             physics: const NeverScrollableScrollPhysics(),
             gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
               crossAxisCount: isDesktop ? 4 : (isTablet ? 3 : 2),
-              childAspectRatio: isDesktop ? 1.15 : (isTablet ? 1.1 : 1.05), // Fix overflow
+              childAspectRatio: isDesktop ? 1.15 : (isTablet ? 1.05 : 0.95), // Slightly taller on smaller screens
               crossAxisSpacing: 20,
               mainAxisSpacing: 20,
             ),
@@ -1113,7 +1113,7 @@ class _AdminHubPageState extends State<AdminHubPage>
                   
                   // Content
                   Padding(
-                    padding: const EdgeInsets.all(20),
+                    padding: const EdgeInsets.all(16),
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [


### PR DESCRIPTION
Fix RenderFlex overflow in admin hub feature cards by adjusting padding and grid child aspect ratio.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2e2c383-da05-47e8-92d0-5353db2f7d28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2e2c383-da05-47e8-92d0-5353db2f7d28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

