### PR TITLE
Fix control panel app rendering and icon issues

### DIFF
--- a/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
+++ b/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
@@ -923,7 +923,8 @@ class _AdminHubPageState extends State<AdminHubPage>
               const SizedBox(height: 12),
               
               // Value and Label
-              Expanded(
+              Flexible(
+                fit: FlexFit.loose,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -941,6 +942,8 @@ class _AdminHubPageState extends State<AdminHubPage>
                               color: AppTheme.textWhite,
                               fontSize: 20,
                             ),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
                           );
                         },
                       ),
@@ -951,6 +954,8 @@ class _AdminHubPageState extends State<AdminHubPage>
                       style: AppTextStyles.caption.copyWith(
                         color: AppTheme.textMuted,
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ],
                 ),

--- a/control_panel_app/pubspec.yaml
+++ b/control_panel_app/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  cupertino_icons: ^1.0.8
   
   # State Management & DI
   flutter_bloc: ^8.1.6


### PR DESCRIPTION
Fixes `RenderFlex` overflow in `admin_hub_page.dart` and resolves `CupertinoIcons` rendering as glyphs.

The `RenderFlex` overflow was caused by text exceeding available space in the admin hub's stat cards, now resolved by using `Flexible` and truncating text. `CupertinoIcons` were rendering as fallback glyphs because the `cupertino_icons` package was not included in the project dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-9252d78e-dc45-4d5a-9941-4912daeb66d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9252d78e-dc45-4d5a-9941-4912daeb66d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

