### PR TITLE
Fix payment analytics bloc registration

### DIFF
--- a/control_panel_app/lib/injection_container.dart
+++ b/control_panel_app/lib/injection_container.dart
@@ -513,11 +513,11 @@ import 'features/admin_bookings/presentation/bloc/booking_analytics/booking_anal
     as ab_an_bloc;
 
 // Payments feature imports
-import 'features/admin_payments/presentation/bloc/payments_list/payments_list_bloc.dart'
+import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payments_list/payments_list_bloc.dart'
     as pay_list_bloc;
-import 'features/admin_payments/presentation/bloc/payment_details/payment_details_bloc.dart'
+import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_details/payment_details_bloc.dart'
     as pay_details_bloc;
-import 'features/admin_payments/presentation/bloc/payment_refund/payment_refund_bloc.dart'
+import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_refund/payment_refund_bloc.dart'
     as pay_refund_bloc;
 import 'features/admin_payments/domain/repositories/payments_repository.dart'
     as pay_repo;
@@ -557,7 +557,7 @@ import 'features/admin_payments/domain/usecases/analytics/get_payment_trends_use
     as pay_uc_trends;
 import 'features/admin_payments/domain/usecases/analytics/get_refund_statistics_usecase.dart'
     as pay_uc_refund_stats;
-import 'features/admin_payments/presentation/bloc/payment_analytics/payment_analytics_bloc.dart'
+import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_analytics/payment_analytics_bloc.dart'
     as pay_an_bloc;
 
 final sl = GetIt.instance;


### PR DESCRIPTION
Update `injection_container.dart` to use `package:` imports for payment BLoCs to resolve `GetIt` type registration mismatches.

The `GetIt` dependency injection library treats types imported via relative paths differently from those imported via `package:` paths, even if they refer to the same file. This caused `PaymentAnalyticsBloc` to be registered under one type identity and requested under another, leading to a "not registered" error. Standardizing to `package:` imports ensures consistent type resolution.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f217aa8-0563-46b4-9ca8-9bf1a4a2e915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f217aa8-0563-46b4-9ca8-9bf1a4a2e915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

