### PR TITLE
Fix material widget and provider errors

### DIFF
--- a/control_panel_app/lib/features/admin_payments/presentation/widgets/payment_filters_widget.dart
+++ b/control_panel_app/lib/features/admin_payments/presentation/widgets/payment_filters_widget.dart
@@ -792,68 +792,71 @@ class _PaymentFiltersWidgetState extends State<PaymentFiltersWidget>
   void _showStatusFilter() {
     showCupertinoModalPopup(
       context: context,
-      builder: (context) => Container(
-        height: 300,
-        decoration: BoxDecoration(
-          color: AppTheme.darkCard,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        child: Column(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(
-                    color: AppTheme.darkBorder.withValues(alpha: 0.2),
+      builder: (context) => Material(
+        color: Colors.transparent,
+        child: Container(
+          height: 300,
+          decoration: BoxDecoration(
+            color: AppTheme.darkCard,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: AppTheme.darkBorder.withValues(alpha: 0.2),
+                    ),
                   ),
                 ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    'اختر حالة الدفعة',
-                    style: AppTextStyles.heading3.copyWith(
-                      color: AppTheme.textWhite,
-                    ),
-                  ),
-                  GestureDetector(
-                    onTap: () => Navigator.pop(context),
-                    child: Icon(
-                      CupertinoIcons.xmark_circle_fill,
-                      color: AppTheme.textMuted,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: ListView(
-                children: PaymentStatus.values.map((status) {
-                  return ListTile(
-                    title: Text(
-                      _getStatusText(status),
-                      style: AppTextStyles.bodyMedium.copyWith(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'اختر حالة الدفعة',
+                      style: AppTextStyles.heading3.copyWith(
                         color: AppTheme.textWhite,
                       ),
                     ),
-                    trailing: _selectedStatus == status
-                        ? Icon(
-                            CupertinoIcons.checkmark_circle_fill,
-                            color: AppTheme.primaryBlue,
-                          )
-                        : null,
-                    onTap: () {
-                      setState(() => _selectedStatus = status);
-                      Navigator.pop(context);
-                      _applyFilters();
-                    },
-                  );
-                }).toList(),
+                    GestureDetector(
+                      onTap: () => Navigator.pop(context),
+                      child: Icon(
+                        CupertinoIcons.xmark_circle_fill,
+                        color: AppTheme.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+              Expanded(
+                child: ListView(
+                  children: PaymentStatus.values.map((status) {
+                    return ListTile(
+                      title: Text(
+                        _getStatusText(status),
+                        style: AppTextStyles.bodyMedium.copyWith(
+                          color: AppTheme.textWhite,
+                        ),
+                      ),
+                      trailing: _selectedStatus == status
+                          ? Icon(
+                              CupertinoIcons.checkmark_circle_fill,
+                              color: AppTheme.primaryBlue,
+                            )
+                          : null,
+                      onTap: () {
+                        setState(() => _selectedStatus = status);
+                        Navigator.pop(context);
+                        _applyFilters();
+                      },
+                    );
+                  }).toList(),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -862,68 +865,71 @@ class _PaymentFiltersWidgetState extends State<PaymentFiltersWidget>
   void _showMethodFilter() {
     showCupertinoModalPopup(
       context: context,
-      builder: (context) => Container(
-        height: 350,
-        decoration: BoxDecoration(
-          color: AppTheme.darkCard,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
-        ),
-        child: Column(
-          children: [
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(
-                    color: AppTheme.darkBorder.withValues(alpha: 0.2),
+      builder: (context) => Material(
+        color: Colors.transparent,
+        child: Container(
+          height: 350,
+          decoration: BoxDecoration(
+            color: AppTheme.darkCard,
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          child: Column(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: AppTheme.darkBorder.withValues(alpha: 0.2),
+                    ),
                   ),
                 ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    'اختر طريقة الدفع',
-                    style: AppTextStyles.heading3.copyWith(
-                      color: AppTheme.textWhite,
-                    ),
-                  ),
-                  GestureDetector(
-                    onTap: () => Navigator.pop(context),
-                    child: Icon(
-                      CupertinoIcons.xmark_circle_fill,
-                      color: AppTheme.textMuted,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Expanded(
-              child: ListView(
-                children: PaymentMethod.values.map((method) {
-                  return ListTile(
-                    title: Text(
-                      _getMethodText(method),
-                      style: AppTextStyles.bodyMedium.copyWith(
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      'اختر طريقة الدفع',
+                      style: AppTextStyles.heading3.copyWith(
                         color: AppTheme.textWhite,
                       ),
                     ),
-                    trailing: _selectedMethod == method
-                        ? Icon(
-                            CupertinoIcons.checkmark_circle_fill,
-                            color: AppTheme.primaryBlue,
-                          )
-                        : null,
-                    onTap: () {
-                      setState(() => _selectedMethod = method);
-                      Navigator.pop(context);
-                      _applyFilters();
-                    },
-                  );
-                }).toList(),
+                    GestureDetector(
+                      onTap: () => Navigator.pop(context),
+                      child: Icon(
+                        CupertinoIcons.xmark_circle_fill,
+                        color: AppTheme.textMuted,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ],
+              Expanded(
+                child: ListView(
+                  children: PaymentMethod.values.map((method) {
+                    return ListTile(
+                      title: Text(
+                        _getMethodText(method),
+                        style: AppTextStyles.bodyMedium.copyWith(
+                          color: AppTheme.textWhite,
+                        ),
+                      ),
+                      trailing: _selectedMethod == method
+                          ? Icon(
+                              CupertinoIcons.checkmark_circle_fill,
+                              color: AppTheme.primaryBlue,
+                            )
+                          : null,
+                      onTap: () {
+                        setState(() => _selectedMethod = method);
+                        Navigator.pop(context);
+                        _applyFilters();
+                      },
+                    );
+                  }).toList(),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/control_panel_app/lib/routes/app_router.dart
+++ b/control_panel_app/lib/routes/app_router.dart
@@ -147,7 +147,8 @@ import 'package:bookn_cp_app/features/admin_payments/presentation/pages/refunds_
 import 'package:bookn_cp_app/features/admin_payments/presentation/pages/revenue_dashboard_page.dart';
 import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payments_list/payments_list_bloc.dart';
 import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_details/payment_details_bloc.dart';
-import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_analytics/payment_analytics_bloc.dart';
+import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_analytics/payment_analytics_bloc.dart'
+    as pay_an_bloc;
 import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_refund/payment_refund_bloc.dart';
 
 class AppRouter {
@@ -269,8 +270,8 @@ class AppRouter {
         GoRoute(
           path: '/admin/payments/analytics',
           builder: (context, state) {
-            return BlocProvider<PaymentAnalyticsBloc>(
-              create: (_) => di.sl<PaymentAnalyticsBloc>(),
+            return BlocProvider<pay_an_bloc.PaymentAnalyticsBloc>(
+              create: (_) => di.sl<pay_an_bloc.PaymentAnalyticsBloc>(),
               child: const PaymentAnalyticsPage(),
             );
           },


### PR DESCRIPTION
Fix "No Material widget found" for ListTiles in modals and "GetIt not registered" for PaymentAnalyticsBloc.

The "No Material widget found" error was resolved by wrapping the content of `showCupertinoModalPopup` with a `Material` widget, providing the necessary Material context for `ListTile` widgets. The "GetIt not registered" error for `PaymentAnalyticsBloc` was fixed by ensuring the `BlocProvider` in `app_router.dart` uses the same import alias for the bloc as it was registered with in the dependency injection container.

---
<a href="https://cursor.com/background-agent?bcId=bc-18d0e477-3a12-45c8-bfe9-bc1d52d6e0ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18d0e477-3a12-45c8-bfe9-bc1d52d6e0ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

