### PR TITLE
Fix getit registration for payment analytics bloc

### DIFF
--- a/control_panel_app/lib/routes/app_router.dart
+++ b/control_panel_app/lib/routes/app_router.dart
@@ -271,7 +271,12 @@ class AppRouter {
           path: '/admin/payments/analytics',
           builder: (context, state) {
             return BlocProvider<pay_an_bloc.PaymentAnalyticsBloc>(
-              create: (_) => di.sl<pay_an_bloc.PaymentAnalyticsBloc>(),
+              create: (_) => pay_an_bloc.PaymentAnalyticsBloc(
+                getPaymentAnalyticsUseCase: di.sl(),
+                getRevenueReportUseCase: di.sl(),
+                getPaymentTrendsUseCase: di.sl(),
+                getRefundStatisticsUseCase: di.sl(),
+              ),
               child: const PaymentAnalyticsPage(),
             );
           },


### PR DESCRIPTION
Instantiate `PaymentAnalyticsBloc` directly in `BlocProvider` to resolve a GetIt registration error during bloc creation.

The error "Bad state: GetIt: Object/factory with type PaymentAnalyticsBloc is not registered inside GetIt" occurred because `BlocProvider`'s `create` method failed to retrieve `PaymentAnalyticsBloc` from `GetIt`. This PR fixes it by explicitly creating the `PaymentAnalyticsBloc` instance within the `BlocProvider`, while still injecting its required use cases (which are correctly registered) from `GetIt`. This bypasses the problematic direct `GetIt` lookup for the bloc itself at this specific point.

---
<a href="https://cursor.com/background-agent?bcId=bc-56b82bba-a443-4966-b001-452ee9f5d678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-56b82bba-a443-4966-b001-452ee9f5d678">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

