### PR TITLE
Fix currency type errors in currencies page

### DIFF
--- a/control_panel_app/lib/features/admin_currencies/presentation/pages/currencies_management_page.dart
+++ b/control_panel_app/lib/features/admin_currencies/presentation/pages/currencies_management_page.dart
@@ -287,12 +287,15 @@ class _CurrenciesManagementPageState extends State<CurrenciesManagementPage>
         builder: (context, state) {
           if (state is! CurrenciesLoaded) return const SizedBox.shrink();
 
-          final defaultCurrency = state.currencies.isNotEmpty
-              ? state.currencies.firstWhere(
-                  (c) => c.isDefault,
-                  orElse: () => state.currencies.first,
-                )
-              : null;
+          Currency? defaultCurrency;
+          if (state.currencies.isNotEmpty) {
+            final maybeDefault = state.currencies.where((c) => c.isDefault);
+            defaultCurrency = maybeDefault.isNotEmpty
+                ? maybeDefault.first
+                : state.currencies.first;
+          } else {
+            defaultCurrency = null;
+          }
 
           if (defaultCurrency == null) {
             return const SizedBox.shrink();

--- a/control_panel_app/lib/features/admin_currencies/presentation/widgets/currency_stats_card.dart
+++ b/control_panel_app/lib/features/admin_currencies/presentation/widgets/currency_stats_card.dart
@@ -160,12 +160,13 @@ class CurrencyStatsCard extends StatelessWidget {
   }
 
   Map<String, dynamic> _calculateStats() {
-    final defaultCurrency = currencies.isNotEmpty
-        ? currencies.firstWhere(
-            (c) => c.isDefault,
-            orElse: () => currencies.first,
-          )
-        : null;
+    Currency? defaultCurrency;
+    if (currencies.isNotEmpty) {
+      final maybeDefault = currencies.where((c) => c.isDefault);
+      defaultCurrency = maybeDefault.isNotEmpty ? maybeDefault.first : currencies.first;
+    } else {
+      defaultCurrency = null;
+    }
 
     final ratesCount = currencies.where((c) => c.exchangeRate != null).length;
     final avgRate = ratesCount > 0


### PR DESCRIPTION
Refactor default currency selection to fix `_TypeError` from `firstWhere(orElse:)` runtime type mismatch.

The `firstWhere` method's `orElse` callback was causing a runtime `_TypeError` due to Dart's generic reification inferring an incorrect type for the callback. The fix replaces this with explicit checks to ensure a consistent `Currency` type is always returned or null, preventing the type mismatch.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e4cc4f9-c7c2-41e6-9ad7-cd3d993682e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e4cc4f9-c7c2-41e6-9ad7-cd3d993682e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

