### PR TITLE
Debug and fix image features in control panel app

### DIFF
--- a/control_panel_app/lib/features/admin_properties/data/datasources/property_images_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_properties/data/datasources/property_images_remote_datasource.dart
@@ -88,7 +88,12 @@ class PropertyImagesRemoteDataSourceImpl implements PropertyImagesRemoteDataSour
   @override
   Future<List<PropertyImageModel>> getPropertyImages(String? propertyId, {String? tempKey}) async {
     try {
-      final qp = <String, dynamic>{'propertyId': propertyId};
+      final qp = <String, dynamic>{
+        'propertyId': propertyId,
+        // ensure backend returns in display order by default
+        'sortBy': 'order',
+        'sortOrder': 'asc',
+      };
       if (tempKey != null) qp['tempKey'] = tempKey;
       final response = await apiClient.get('$_imagesEndpoint', queryParameters: qp);
       

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/property_images/property_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/property_images/property_images_bloc.dart
@@ -342,8 +342,8 @@ class PropertyImagesBloc extends Bloc<PropertyImagesEvent, PropertyImagesState> 
             }
           }
           
-          // إعادة تحميل الصور للحصول على البيانات المحدثة
-          add(LoadPropertyImagesEvent(propertyId: event.propertyId));
+          // إعادة تحميل الصور للحصول على البيانات المحدثة (يجب تمرير tempKey إن وُجد)
+          add(LoadPropertyImagesEvent(propertyId: event.propertyId, tempKey: event.tempKey));
         }
       },
     );

--- a/control_panel_app/lib/features/admin_properties/presentation/pages/create_property_page.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/pages/create_property_page.dart
@@ -638,6 +638,11 @@ class _CreatePropertyViewState extends State<_CreatePropertyView>
               propertyId: null, // لا يوجد معرف بعد
               tempKey: _tempKey,
               maxImages: 10,
+              onImagesChanged: (images) {
+                setState(() {
+                  _selectedImages = images;
+                });
+              },
               onLocalImagesChanged: (paths) {
                 setState(() {
                   _selectedLocalImages = paths;

--- a/control_panel_app/lib/features/admin_units/data/datasources/unit_images_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_units/data/datasources/unit_images_remote_datasource.dart
@@ -88,7 +88,11 @@ class UnitImagesRemoteDataSourceImpl implements UnitImagesRemoteDataSource {
   @override
   Future<List<UnitImageModel>> getUnitImages(String? unitId, {String? tempKey}) async {
     try {
-      final qp = <String, dynamic>{'unitId': unitId};
+      final qp = <String, dynamic>{
+        'unitId': unitId,
+        'sortBy': 'order',
+        'sortOrder': 'asc',
+      };
       if (tempKey != null) qp['tempKey'] = tempKey;
       final response = await apiClient.get('$_imagesEndpoint', queryParameters: qp);
       

--- a/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/bloc/unit_images/unit_images_bloc.dart
@@ -343,8 +343,8 @@ class UnitImagesBloc extends Bloc<UnitImagesEvent, UnitImagesState> {
             }
           }
 
-          // إعادة تحميل الصور للحصول على البيانات المحدثة
-          add(LoadUnitImagesEvent(unitId: event.unitId));
+          // إعادة تحميل الصور للحصول على البيانات المحدثة (الحفاظ على tempKey)
+          add(LoadUnitImagesEvent(unitId: event.unitId, tempKey: event.tempKey));
         }
       },
     );


### PR DESCRIPTION
Fix image sorting, primary assignment, and property creation wizard image detection.

The backend `GetImagesQueryHandler` now correctly maps `IsPrimary` from `IsMainImage` and defaults to `DisplayOrder` sorting. Flutter data sources (`PropertyImagesRemoteDataSource`, `UnitImagesRemoteDataSource`) now explicitly request images sorted by order. `PropertyImagesBloc` and `UnitImagesBloc` preserve `tempKey` when refreshing after setting a primary image. Finally, `CreatePropertyPage` now updates `_selectedImages` via `onImagesChanged` from `PropertyImageGallery`, resolving the issue where the wizard didn't detect uploaded images in remote mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-70c4b8a1-66cd-4f4b-b4e3-3fc6fa3be8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-70c4b8a1-66cd-4f4b-b4e3-3fc6fa3be8b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

