### PR TITLE
Fix rendering overflow and layout issues

### DIFF
--- a/control_panel_app/lib/features/admin_properties/presentation/pages/properties_list_page.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/pages/properties_list_page.dart
@@ -154,7 +154,8 @@ class _PropertiesListPageState extends State<PropertiesListPage>
                 ),
 
               // Content Area - المحتوى الرئيسي
-              SliverToBoxAdapter(
+              SliverFillRemaining(
+                hasScrollBody: true,
                 child: FadeTransition(
                   opacity: _contentFadeAnimation,
                   child: SlideTransition(
@@ -415,7 +416,7 @@ class _PropertiesListPageState extends State<PropertiesListPage>
 
   Widget _buildStatsSection() {
     return Container(
-      height: 120,
+      height: 128,
       padding: const EdgeInsets.all(16),
       child: BlocBuilder<PropertiesBloc, PropertiesState>(
         builder: (context, state) {

--- a/control_panel_app/lib/features/admin_properties/presentation/widgets/futuristic_property_table.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/widgets/futuristic_property_table.dart
@@ -90,6 +90,8 @@ class _FuturisticPropertyTableState extends State<FuturisticPropertyTable>
       child: ListView.builder(
         padding: const EdgeInsets.all(12),
         itemCount: widget.properties.length,
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
         itemBuilder: (context, index) {
           final property = widget.properties[index];
           return _buildMobileCard(property);

--- a/control_panel_app/lib/features/admin_properties/presentation/widgets/property_stats_card.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/widgets/property_stats_card.dart
@@ -130,7 +130,8 @@ class _PropertyStatsCardState extends State<PropertyStatsCard>
                             padding: EdgeInsets.all(padding),
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
-                              mainAxisSize: MainAxisSize.min,
+                              mainAxisSize: MainAxisSize.max,
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [
                                 // الصف العلوي - الأيقونة والترند
                                 Flexible(
@@ -214,8 +215,7 @@ class _PropertyStatsCardState extends State<PropertyStatsCard>
                                   ),
                                 ),
                                 
-                                // مساحة مرنة
-                                const Expanded(child: SizedBox()),
+                                // تم توزيع المساحة باستخدام spaceBetween بدل Expanded لتجنب overflow
                                 
                                 // القيمة والعنوان
                                 Flexible(


### PR DESCRIPTION
Resolve rendering overflow and unbounded height issues in property list, stats cards, and property table.

This PR fixes `RenderFlex overflow` in `PropertyStatsCard` by adjusting `Column` alignment and removing an `Expanded` widget. It also addresses `Vertical viewport was given unbounded height` and related `RenderBox not laid out` errors in `FuturisticPropertyTable` by using `SliverFillRemaining` for the main content and setting `shrinkWrap` and `NeverScrollableScrollPhysics` for the mobile `ListView`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f7bb8c5-83c1-4439-9163-11f4cd95169d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3f7bb8c5-83c1-4439-9163-11f4cd95169d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

