### PR TITLE
Fix property type update and add currency field

### DIFF
--- a/backend/YemenBooking.Application/Commands/CP/Properties/CreatePropertyCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Properties/CreatePropertyCommand.cs
@@ -74,4 +74,28 @@ public class CreatePropertyCommand : IRequest<ResultDto<Guid>>
     /// Updated property images
     /// </summary>
     public List<string> Images { get; set; } = new List<string>();
+
+    /// <summary>
+    /// وصف مختصر للكيان
+    /// Short description
+    /// </summary>
+    public string? ShortDescription { get; set; }
+
+    /// <summary>
+    /// السعر الأساسي لليلة
+    /// Base price per night
+    /// </summary>
+    public decimal? BasePricePerNight { get; set; }
+
+    /// <summary>
+    /// رمز العملة (YER, USD, ...)
+    /// Currency code
+    /// </summary>
+    public string? Currency { get; set; }
+
+    /// <summary>
+    /// هل العقار مميز؟
+    /// Is featured
+    /// </summary>
+    public bool? IsFeatured { get; set; }
 } 

--- a/backend/YemenBooking.Application/Commands/CP/Properties/UpdatePropertyCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Properties/UpdatePropertyCommand.cs
@@ -63,4 +63,28 @@ public class UpdatePropertyCommand : IRequest<ResultDto<bool>>
     /// </summary>
     public List<string> Images { get; set; } = new List<string>();
 
+    /// <summary>
+    /// وصف مختصر
+    /// Short description
+    /// </summary>
+    public string? ShortDescription { get; set; }
+
+    /// <summary>
+    /// السعر الأساسي لليلة
+    /// Base price per night
+    /// </summary>
+    public decimal? BasePricePerNight { get; set; }
+
+    /// <summary>
+    /// رمز العملة
+    /// Currency code
+    /// </summary>
+    public string? Currency { get; set; }
+
+    /// <summary>
+    /// عقار مميز؟
+    /// Is featured
+    /// </summary>
+    public bool? IsFeatured { get; set; }
+
 } 

--- a/backend/YemenBooking.Application/Commands/CP/UnitTypeFields/UpdateUnitTypeFieldCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/UnitTypeFields/UpdateUnitTypeFieldCommand.cs
@@ -104,4 +104,10 @@ public class UpdateUnitTypeFieldCommand : IRequest<ResultDto<Unit>>
     /// Order priority
     /// </summary>
     public int? Priority { get; set; }
+
+    /// <summary>
+    /// نوع الحقل (اختياري عند التحديث)
+    /// FieldTypeId (optional on update)
+    /// </summary>
+    public string? FieldTypeId { get; set; }
 }

--- a/backend/YemenBooking.Application/Handlers/Commands/Properties/CreatePropertyCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Properties/CreatePropertyCommandHandler.cs
@@ -101,13 +101,16 @@ namespace YemenBooking.Application.Handlers.Commands.Properties
                 TypeId = request.PropertyTypeId,
                 Name = request.Name,
                 Address = request.Address,
+                ShortDescription = string.IsNullOrWhiteSpace(request.ShortDescription) ? null : request.ShortDescription,
                 Description = request.Description,
                 City = request.City,
-                Currency = "YER", // العملة الافتراضية
+                Currency = string.IsNullOrWhiteSpace(request.Currency) ? "YER" : request.Currency!.ToUpperInvariant(),
+                BasePricePerNight = request.BasePricePerNight ?? 0m,
                 Latitude = (decimal)request.Latitude,
                 Longitude = (decimal)request.Longitude,
                 StarRating = request.StarRating,
                 IsApproved = false,
+                IsFeatured = request.IsFeatured ?? false,
                 CreatedBy = _currentUserService.UserId,
                 CreatedAt = DateTime.UtcNow
             };

--- a/backend/YemenBooking.Application/Handlers/Commands/Properties/UpdatePropertyCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Properties/UpdatePropertyCommandHandler.cs
@@ -67,9 +67,11 @@ namespace YemenBooking.Application.Handlers.Commands.Properties
 
             // إذا كان الكيان معتمدًا وتم تعديل بيانات حساسة، إعادة تعيين الموافقة
             bool requiresReapproval = property.IsApproved &&
-                (!string.IsNullOrWhiteSpace(request.Name) && request.Name != property.Name ||
-                 !string.IsNullOrWhiteSpace(request.Address) && request.Address != property.Address ||
-                 request.StarRating.HasValue && request.StarRating.Value != property.StarRating);
+                ((!string.IsNullOrWhiteSpace(request.Name) && request.Name != property.Name) ||
+                 (!string.IsNullOrWhiteSpace(request.Address) && request.Address != property.Address) ||
+                 (request.StarRating.HasValue && request.StarRating.Value != property.StarRating) ||
+                 (!string.IsNullOrWhiteSpace(request.Currency) && !string.Equals(property.Currency, request.Currency, StringComparison.OrdinalIgnoreCase)) ||
+                 (request.BasePricePerNight.HasValue && request.BasePricePerNight.Value != property.BasePricePerNight));
             if (requiresReapproval)
                 property.IsApproved = false;
 
@@ -80,10 +82,18 @@ namespace YemenBooking.Application.Handlers.Commands.Properties
                 property.Address = request.Address;
             if (!string.IsNullOrWhiteSpace(request.Description))
                 property.Description = request.Description;
+            if (!string.IsNullOrWhiteSpace(request.ShortDescription))
+                property.ShortDescription = request.ShortDescription;
             if (!string.IsNullOrWhiteSpace(request.City))
                 property.City = request.City;
             if (request.StarRating.HasValue)
                 property.StarRating = request.StarRating.Value;
+            if (!string.IsNullOrWhiteSpace(request.Currency))
+                property.Currency = request.Currency!.ToUpperInvariant();
+            if (request.BasePricePerNight.HasValue)
+                property.BasePricePerNight = request.BasePricePerNight.Value;
+            if (request.IsFeatured.HasValue)
+                property.IsFeatured = request.IsFeatured.Value;
             if (request.Latitude.HasValue && request.Latitude.Value >= -90 && request.Latitude.Value <= 90)
                 property.Latitude = (decimal)request.Latitude.Value;
             if (request.Longitude.HasValue && request.Longitude.Value >= -180 && request.Longitude.Value <= 180)

--- a/backend/YemenBooking.Application/Handlers/Commands/UnitTypeFields/UpdateUnitTypeFieldCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/UnitTypeFields/UpdateUnitTypeFieldCommandHandler.cs
@@ -161,6 +161,10 @@ public class UpdateUnitTypeFieldCommandHandler : IRequestHandler<UpdateUnitTypeF
             existingField.ShowInCards = request.ShowInCards ?? existingField.ShowInCards;
             existingField.IsPrimaryFilter = request.IsPrimaryFilter ?? existingField.IsPrimaryFilter;
             existingField.Priority = request.Priority ?? existingField.Priority;
+            if (!string.IsNullOrWhiteSpace(request.FieldTypeId) && !string.Equals(existingField.FieldTypeId, request.FieldTypeId, StringComparison.OrdinalIgnoreCase))
+            {
+                existingField.FieldTypeId = request.FieldTypeId!;
+            }
             existingField.UpdatedAt = DateTime.UtcNow;
 
             var updatedField = await _unitTypeFieldRepository.UpdateUnitTypeFieldAsync(existingField, cancellationToken);

--- a/control_panel_app/lib/features/admin_properties/data/datasources/properties_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_properties/data/datasources/properties_remote_datasource.dart
@@ -136,6 +136,16 @@ class PropertiesRemoteDataSourceImpl implements PropertiesRemoteDataSource {
           }
         }
       }
+      // Ensure currency is sent via header for context if provided
+      try {
+        final currency = propertyData['currency'];
+        if (currency != null && currency is String && currency.isNotEmpty) {
+          apiClient.addRequestInterceptor((options) {
+            options.headers[ApiConstants.xPropertyCurrency] = currency;
+            return options;
+          });
+        }
+      } catch (_) {}
       final response = await apiClient.post(
         _baseEndpoint,
         data: propertyData,
@@ -163,6 +173,16 @@ class PropertiesRemoteDataSourceImpl implements PropertiesRemoteDataSource {
           }
         }
       }
+      // Ensure currency header if provided
+      try {
+        final currency = propertyData['currency'];
+        if (currency != null && currency is String && currency.isNotEmpty) {
+          apiClient.addRequestInterceptor((options) {
+            options.headers[ApiConstants.xPropertyCurrency] = currency;
+            return options;
+          });
+        }
+      } catch (_) {}
       final response = await apiClient.put(
         '$_baseEndpoint/$propertyId',
         data: propertyData,

--- a/control_panel_app/lib/features/admin_properties/domain/usecases/properties/create_property_usecase.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/usecases/properties/create_property_usecase.dart
@@ -18,6 +18,10 @@ class CreatePropertyParams {
   final List<String>? images;
   final List<String>? amenityIds; // أضف هذا السطر
   final String? tempKey;
+  final String shortDescription;
+  final double basePricePerNight;
+  final String currency;
+  final bool isFeatured;
   
   CreatePropertyParams({
     required this.name,
@@ -32,6 +36,10 @@ class CreatePropertyParams {
     this.images,
     this.amenityIds, // أضف هذا السطر
     this.tempKey,
+    required this.shortDescription,
+    required this.basePricePerNight,
+    required this.currency,
+    required this.isFeatured,
   });
   
   Map<String, dynamic> toJson() {
@@ -45,6 +53,10 @@ class CreatePropertyParams {
     'longitude': longitude,
     'city': city,
     'starRating': starRating,
+      'shortDescription': shortDescription,
+      'basePricePerNight': basePricePerNight,
+      'currency': currency,
+      'isFeatured': isFeatured,
       if (images != null && images!.isNotEmpty) 'images': images,
       if (amenityIds != null && amenityIds!.isNotEmpty) 'amenityIds': amenityIds,
       if (tempKey != null && tempKey!.isNotEmpty) 'tempKey': tempKey,

--- a/control_panel_app/lib/features/admin_properties/domain/usecases/properties/update_property_usecase.dart
+++ b/control_panel_app/lib/features/admin_properties/domain/usecases/properties/update_property_usecase.dart
@@ -15,6 +15,10 @@ class UpdatePropertyParams {
   final String? city;
   final int? starRating;
   final List<String>? images;
+  final String? shortDescription;
+  final double? basePricePerNight;
+  final String? currency;
+  final bool? isFeatured;
   
   UpdatePropertyParams({
     required this.propertyId,
@@ -26,6 +30,10 @@ class UpdatePropertyParams {
     this.city,
     this.starRating,
     this.images,
+    this.shortDescription,
+    this.basePricePerNight,
+    this.currency,
+    this.isFeatured,
   });
   
   Map<String, dynamic> toJson() {
@@ -38,6 +46,10 @@ class UpdatePropertyParams {
     if (city != null) data['city'] = city;
     if (starRating != null) data['starRating'] = starRating;
     if (images != null) data['images'] = images;
+    if (shortDescription != null) data['shortDescription'] = shortDescription;
+    if (basePricePerNight != null) data['basePricePerNight'] = basePricePerNight;
+    if (currency != null) data['currency'] = currency;
+    if (isFeatured != null) data['isFeatured'] = isFeatured;
     return data;
   }
 }

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_bloc.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_bloc.dart
@@ -113,6 +113,10 @@ class PropertiesBloc extends Bloc<PropertiesEvent, PropertiesState> {
         images: event.images,
         amenityIds: event.amenityIds,
         tempKey: event.tempKey,
+        shortDescription: event.shortDescription,
+        basePricePerNight: event.basePricePerNight,
+        currency: event.currency,
+        isFeatured: event.isFeatured,
       ),
     );
     
@@ -142,6 +146,10 @@ class PropertiesBloc extends Bloc<PropertiesEvent, PropertiesState> {
         city: event.city,
         starRating: event.starRating,
         images: event.images,
+        shortDescription: event.shortDescription,
+        basePricePerNight: event.basePricePerNight,
+        currency: event.currency,
+        isFeatured: event.isFeatured,
       ),
     );
     

--- a/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_event.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/bloc/properties/properties_event.dart
@@ -55,6 +55,10 @@ class CreatePropertyEvent extends PropertiesEvent {
   final List<String>? images;
   final List<String>? amenityIds;
   final String? tempKey;
+  final String shortDescription;
+  final double basePricePerNight;
+  final String currency;
+  final bool isFeatured;
   
   const CreatePropertyEvent({
     required this.name,
@@ -69,16 +73,17 @@ class CreatePropertyEvent extends PropertiesEvent {
     this.images,
     this.amenityIds, 
     this.tempKey,
-    required String shortDescription, 
-    required double basePricePerNight, 
-    required String currency, 
-    required bool isFeatured,
+    required this.shortDescription, 
+    required this.basePricePerNight, 
+    required this.currency, 
+    required this.isFeatured,
   });
   
   @override
   List<Object?> get props => [
     name, address, propertyTypeId, ownerId, description,
     latitude, longitude, city, starRating, images, amenityIds, tempKey,
+    shortDescription, basePricePerNight, currency, isFeatured,
   ];
 }
 
@@ -92,6 +97,10 @@ class UpdatePropertyEvent extends PropertiesEvent {
   final String? city;
   final int? starRating;
   final List<String>? images;
+  final String? shortDescription;
+  final double? basePricePerNight;
+  final String? currency;
+  final bool? isFeatured;
   
   const UpdatePropertyEvent({
     required this.propertyId,
@@ -103,12 +112,17 @@ class UpdatePropertyEvent extends PropertiesEvent {
     this.city,
     this.starRating,
     this.images,
+    this.shortDescription,
+    this.basePricePerNight,
+    this.currency,
+    this.isFeatured,
   });
   
   @override
   List<Object?> get props => [
     propertyId, name, address, description,
     latitude, longitude, city, starRating, images,
+    shortDescription, basePricePerNight, currency, isFeatured,
   ];
 }
 

--- a/control_panel_app/lib/features/property_types/data/datasources/unit_type_fields_remote_datasource.dart
+++ b/control_panel_app/lib/features/property_types/data/datasources/unit_type_fields_remote_datasource.dart
@@ -174,6 +174,7 @@ class UnitTypeFieldsRemoteDataSourceImpl implements UnitTypeFieldsRemoteDataSour
   @override
   Future<bool> updateField({
     required String fieldId,
+    String? fieldTypeId,
     String? fieldName,
     String? displayName,
     String? description,


### PR DESCRIPTION
Fix dynamic field type not updating in property types and add currency selection to property create/edit forms.

The `fieldTypeId` was missing from the update payload for dynamic fields, preventing field type changes from persisting. This PR ensures it's included. Additionally, a currency selector (reusing existing currency fetching logic), base price, short description, and featured status fields are now available and propagated during property creation and editing, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-da4ceda9-2562-43f3-88ea-11a5d01f6486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da4ceda9-2562-43f3-88ea-11a5d01f6486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

