### PR TITLE
Fix currencies bloc provider error in bottom sheet

### DIFF
--- a/control_panel_app/lib/features/admin_currencies/presentation/pages/currencies_management_page.dart
+++ b/control_panel_app/lib/features/admin_currencies/presentation/pages/currencies_management_page.dart
@@ -664,26 +664,27 @@ class _CurrenciesManagementPageState extends State<CurrenciesManagementPage>
 
   void _showCurrencyForm({Currency? currency}) {
     HapticFeedback.mediumImpact();
+    final currenciesBloc = context.read<CurrenciesBloc>();
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (context) => FuturisticCurrencyFormModal(
+      builder: (sheetContext) => FuturisticCurrencyFormModal(
         currency: currency,
         onSave: (updatedCurrency) {
           if (currency == null) {
-            context.read<CurrenciesBloc>().add(
-                  AddCurrencyEvent(currency: updatedCurrency),
-                );
+            currenciesBloc.add(
+              AddCurrencyEvent(currency: updatedCurrency),
+            );
           } else {
-            context.read<CurrenciesBloc>().add(
-                  UpdateCurrencyEvent(
-                    currency: updatedCurrency,
-                    oldCode: currency.code,
-                  ),
-                );
+            currenciesBloc.add(
+              UpdateCurrencyEvent(
+                currency: updatedCurrency,
+                oldCode: currency.code,
+              ),
+            );
           }
-          Navigator.pop(context);
+          Navigator.pop(sheetContext);
         },
       ),
     );
@@ -691,9 +692,10 @@ class _CurrenciesManagementPageState extends State<CurrenciesManagementPage>
 
   void _confirmDeleteCurrency(Currency currency) {
     HapticFeedback.heavyImpact();
+    final currenciesBloc = context.read<CurrenciesBloc>();
     showCupertinoDialog(
       context: context,
-      builder: (context) => BackdropFilter(
+      builder: (dialogContext) => BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
         child: CupertinoAlertDialog(
           title: Text('حذف ${currency.arabicName}'),
@@ -703,16 +705,16 @@ class _CurrenciesManagementPageState extends State<CurrenciesManagementPage>
             CupertinoDialogAction(
               isDestructiveAction: true,
               onPressed: () {
-                context.read<CurrenciesBloc>().add(
-                      DeleteCurrencyEvent(code: currency.code),
-                    );
-                Navigator.pop(context);
+                currenciesBloc.add(
+                  DeleteCurrencyEvent(code: currency.code),
+                );
+                Navigator.pop(dialogContext);
               },
               child: const Text('حذف'),
             ),
             CupertinoDialogAction(
               isDefaultAction: true,
-              onPressed: () => Navigator.pop(context),
+              onPressed: () => Navigator.pop(dialogContext),
               child: const Text('إلغاء'),
             ),
           ],


### PR DESCRIPTION
Fix `ProviderNotFoundError` in bottom sheets and dialogs by capturing `CurrenciesBloc` from the parent context and using the correct builder context for navigation.

The `ProviderNotFoundError` occurred because `context.read<CurrenciesBloc>()` was called within the `builder` of `showModalBottomSheet` or `showCupertinoDialog`. The `builder` provides a new `BuildContext` that is a descendant of the modal/dialog itself, not the `BlocProvider` for `CurrenciesBloc`. By reading the bloc from the original `context` (which is an ancestor of the `BlocProvider`) before opening the modal/dialog, we ensure the bloc instance is correctly accessed. Additionally, `Navigator.pop` now uses the `sheetContext`/`dialogContext` to ensure it operates on the correct navigation stack.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2c579c8-c0ec-450d-868d-d79635d8da79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2c579c8-c0ec-450d-868d-d79635d8da79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

