### PR TITLE
Implement currency deletion checks and fix overflow

### DIFF
--- a/backend/YemenBooking.Api/Controllers/Admin/SystemSettingsController.cs
+++ b/backend/YemenBooking.Api/Controllers/Admin/SystemSettingsController.cs
@@ -83,6 +83,28 @@ namespace YemenBooking.Api.Controllers.Admin
         }
 
         /// <summary>
+        /// حذف عملة نهائياً بعد التحقق من الارتباطات
+        /// Permanently delete a currency after verifying references
+        /// </summary>
+        [HttpDelete("currencies/{code}")]
+        public async Task<ActionResult<ResultDto>> DeleteCurrencyAsync([FromRoute] string code, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _currencySettingsService.DeleteCurrencyAsync(code, cancellationToken);
+                return Ok(ResultDto.Ok("تم حذف العملة بنجاح"));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Conflict(ResultDto.Failure(ex.Message, errorCode: "CURRENCY_DELETE_CONFLICT"));
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(ResultDto.Failure(ex.Message, errorCode: "INVALID_CURRENCY_CODE"));
+            }
+        }
+
+        /// <summary>
         /// حفظ أو تحديث قائمة المدن
         /// Save or update city settings
         /// </summary>

--- a/backend/YemenBooking.Application/Interfaces/Services/ICurrencySettingsService.cs
+++ b/backend/YemenBooking.Application/Interfaces/Services/ICurrencySettingsService.cs
@@ -19,5 +19,11 @@ namespace YemenBooking.Application.Interfaces.Services
         /// Save or update the list of currencies
         /// </summary>
         Task SaveCurrenciesAsync(List<CurrencyDto> currencies, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a currency permanently after verifying there are no references.
+        /// Throws InvalidOperationException with a descriptive message if deletion is not allowed.
+        /// </summary>
+        Task DeleteCurrencyAsync(string code, CancellationToken cancellationToken = default);
     }
 } 

--- a/control_panel_app/lib/core/network/api_exceptions.dart
+++ b/control_panel_app/lib/core/network/api_exceptions.dart
@@ -5,12 +5,14 @@ class ApiException implements Exception {
   final int? statusCode;
   final dynamic data;
   final DioExceptionType? type;
+  final String? code;
 
   ApiException({
     required this.message,
     this.statusCode,
     this.data,
     this.type,
+    this.code,
   });
 
   factory ApiException.fromDioError(DioException dioError) {
@@ -61,6 +63,7 @@ class ApiException implements Exception {
       statusCode: statusCode,
       data: data,
       type: dioError.type,
+      code: data is Map<String, dynamic> ? data['errorCode'] as String? : null,
     );
   }
 

--- a/control_panel_app/lib/features/admin_currencies/data/repositories/currencies_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_currencies/data/repositories/currencies_repository_impl.dart
@@ -80,21 +80,12 @@ class CurrenciesRepositoryImpl implements CurrenciesRepository {
     }
 
     try {
-      // Get current currencies
-      final currentCurrencies = await remoteDataSource.getCurrencies();
-      
-      // Remove the currency with the given code
-      final updatedCurrencies = currentCurrencies
-          .where((c) => c.code != code)
-          .toList();
-      
-      // Save updated list
-      final result = await remoteDataSource.saveCurrencies(updatedCurrencies);
-      
+      final result = await remoteDataSource.deleteCurrency(code);
       if (result) {
-        await localDataSource.cacheCurrencies(updatedCurrencies);
+        // Refresh and cache after delete
+        final current = await remoteDataSource.getCurrencies();
+        await localDataSource.cacheCurrencies(current);
       }
-      
       return Right(result);
     } on ServerException catch (e) {
       return Left(ServerFailure(e.message));

--- a/control_panel_app/lib/features/admin_currencies/presentation/widgets/exchange_rate_indicator.dart
+++ b/control_panel_app/lib/features/admin_currencies/presentation/widgets/exchange_rate_indicator.dart
@@ -198,6 +198,7 @@ class _ExchangeRateIndicatorState extends State<ExchangeRateIndicator>
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
             crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
             children: [
               Text(
                 currency.arabicCode,
@@ -242,12 +243,14 @@ class _ExchangeRateIndicatorState extends State<ExchangeRateIndicator>
                 ],
               ),
               const SizedBox(height: 0),
-              Text(
+              Flexible(
+                child: Text(
                 isUp ? '+0.25%' : '-0.12%',
                 style: AppTextStyles.caption.copyWith(
                   color: isUp ? AppTheme.success : AppTheme.error,
                   fontWeight: FontWeight.w500,
                 ),
+              ),
               ),
             ],
           ),


### PR DESCRIPTION
Implement hard currency deletion with referential integrity checks and fix a `RenderFlex overflow` in the currency exchange rate indicator.

The currency deletion now prevents removal if linked to properties, units, pricing rules, bookings, payments, amenities, or services, as requested, and performs a true hard delete otherwise. The `RenderFlex overflow` was resolved by constraining `Column` sizes and wrapping text with `Flexible`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a6066ddd-9461-4cec-b8b3-16f716d58867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a6066ddd-9461-4cec-b8b3-16f716d58867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

