### PR TITLE
Make city field optional and fetch real cities

### DIFF
--- a/backend/YemenBooking.Api/Controllers/Common/SystemSettingsController.cs
+++ b/backend/YemenBooking.Api/Controllers/Common/SystemSettingsController.cs
@@ -15,11 +15,13 @@ namespace YemenBooking.Api.Controllers.Common
     {
         private readonly ISystemSettingsService _settingsService;
         private readonly ICurrencySettingsService _currencySettingsService;
+        private readonly ICitySettingsService _citySettingsService;
 
-        public SystemSettingsController(ISystemSettingsService settingsService, ICurrencySettingsService currencySettingsService)
+        public SystemSettingsController(ISystemSettingsService settingsService, ICurrencySettingsService currencySettingsService, ICitySettingsService citySettingsService)
         {
             _settingsService = settingsService;
             _currencySettingsService = currencySettingsService;
+            _citySettingsService = citySettingsService;
         }
 
         /// <summary>
@@ -43,6 +45,18 @@ namespace YemenBooking.Api.Controllers.Common
         {
             var currencies = await _currencySettingsService.GetCurrenciesAsync(cancellationToken);
             return Ok(ResultDto<List<CurrencyDto>>.Succeeded(currencies));
+        }
+
+        /// <summary>
+        /// جلب قائمة المدن
+        /// Get city settings
+        /// </summary>
+        [AllowAnonymous]
+        [HttpGet("cities")]
+        public async Task<ActionResult<ResultDto<List<CityDto>>>> GetCitiesAsync(CancellationToken cancellationToken)
+        {
+            var cities = await _citySettingsService.GetCitiesAsync(cancellationToken);
+            return Ok(ResultDto<List<CityDto>>.Succeeded(cities));
         }
     }
 } 

--- a/backend/YemenBooking.Application/Commands/CP/Properties/CreatePropertyCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Properties/CreatePropertyCommand.cs
@@ -58,10 +58,10 @@ public class CreatePropertyCommand : IRequest<ResultDto<Guid>>
     public double Longitude { get; set; }
 
     /// <summary>
-    /// المدينة
-    /// City
+    /// المدينة (اختياري)
+    /// City (optional)
     /// </summary>
-    public string City { get; set; }
+    public string? City { get; set; }
 
     /// <summary>
     /// تقييم النجوم

--- a/backend/YemenBooking.Application/Handlers/Commands/Properties/CreatePropertyCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Properties/CreatePropertyCommandHandler.cs
@@ -73,8 +73,7 @@ namespace YemenBooking.Application.Handlers.Commands.Properties
                 return ResultDto<Guid>.Failed("معرف المالك مطلوب");
             if (request.PropertyTypeId == Guid.Empty)
                 return ResultDto<Guid>.Failed("معرف نوع الكيان مطلوب");
-            if (string.IsNullOrWhiteSpace(request.City))
-                return ResultDto<Guid>.Failed("اسم المدينة مطلوب");
+            // City is optional; if provided, normalize spacing
             if (request.StarRating < 1 || request.StarRating > 5)
                 return ResultDto<Guid>.Failed("تقييم النجوم يجب أن يكون بين 1 و 5");
             if (request.Latitude < -90 || request.Latitude > 90)
@@ -103,7 +102,7 @@ namespace YemenBooking.Application.Handlers.Commands.Properties
                 Address = request.Address,
                 ShortDescription = string.IsNullOrWhiteSpace(request.ShortDescription) ? null : request.ShortDescription,
                 Description = request.Description,
-                City = request.City,
+                City = string.IsNullOrWhiteSpace(request.City) ? null : request.City!.Trim(),
                 Currency = string.IsNullOrWhiteSpace(request.Currency) ? "YER" : request.Currency!.ToUpperInvariant(),
                 BasePricePerNight = request.BasePricePerNight ?? 0m,
                 Latitude = (decimal)request.Latitude,

--- a/backend/YemenBooking.Core/Entities/Property.cs
+++ b/backend/YemenBooking.Core/Entities/Property.cs
@@ -58,7 +58,7 @@ public class Property : BaseEntity<Guid>
     /// City
     /// </summary>
     [Display(Name = "المدينة")]
-    public string City { get; set; }
+    public string? City { get; set; }
     
     /// <summary>
     /// خط العرض

--- a/backend/YemenBooking.Infrastructure/Data/Configurations/PropertyConfiguration.cs
+++ b/backend/YemenBooking.Infrastructure/Data/Configurations/PropertyConfiguration.cs
@@ -30,7 +30,7 @@ public class PropertyConfiguration : IEntityTypeConfiguration<Property>
         builder.Property(p => p.TypeId).IsRequired();
         builder.Property(p => p.Name).IsRequired().HasMaxLength(100);
         builder.Property(p => p.Address).IsRequired().HasMaxLength(500);
-        builder.Property(p => p.City).IsRequired().HasMaxLength(50);
+        builder.Property(p => p.City).HasMaxLength(50);
         builder.Property(p => p.Latitude).HasColumnType("decimal(9,6)");
         builder.Property(p => p.Longitude).HasColumnType("decimal(9,6)");
         builder.Property(p => p.StarRating).HasDefaultValue(0);

--- a/backend/YemenBooking.Infrastructure/DependencyInjection.cs
+++ b/backend/YemenBooking.Infrastructure/DependencyInjection.cs
@@ -19,6 +19,8 @@ public static class DependencyInjection
 	{
 		// إضافة خدمات أخرى
 		services.AddHttpClient<ICurrencyExchangeService, CurrencyExchangeService>();
+		services.AddScoped<ICurrencySettingsService, CurrencySettingsService>();
+		services.AddScoped<ICitySettingsService, CitySettingsService>();
 		services.AddScoped<IEmailVerificationService, EmailVerificationService>();
 		services.AddScoped<IFileUploadService, FileUploadService>();
 		services.AddScoped<IPasswordResetService, PasswordResetService>();


### PR DESCRIPTION
Make the property city field optional and use a dynamic dropdown for city selection, mirroring the currency selection mechanism.

---
<a href="https://cursor.com/background-agent?bcId=bc-a07772d6-886c-4861-a3e9-5f4550b02a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a07772d6-886c-4861-a3e9-5f4550b02a6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

