### PR TITLE
Fix dynamic fields not showing in control panel

### DIFF
--- a/control_panel_app/lib/features/admin_units/data/models/unit_field_value_model.dart
+++ b/control_panel_app/lib/features/admin_units/data/models/unit_field_value_model.dart
@@ -12,10 +12,35 @@ class UnitFieldValueModel extends UnitFieldValue {
 
   factory UnitFieldValueModel.fromJson(Map<String, dynamic> json) {
     final fieldObj = json['field'] as Map<String, dynamic>?;
+
+    bool? _coerceBool(dynamic v) {
+      if (v == null) return null;
+      if (v is bool) return v;
+      if (v is num) return v != 0;
+      if (v is String) {
+        final s = v.toLowerCase().trim();
+        if (s == 'true' || s == '1' || s == 'yes' || s == 'y') return true;
+        if (s == 'false' || s == '0' || s == 'no' || s == 'n') return false;
+      }
+      return null;
+    }
+
+    String _coerceString(dynamic v) {
+      if (v == null) return '';
+      return v.toString();
+    }
+
+    final rawIsPrimary = json.containsKey('isPrimaryFilter')
+        ? json['isPrimaryFilter']
+        : fieldObj?['isPrimaryFilter'];
+
     return UnitFieldValueModel(
       fieldId: json['fieldId'] as String,
-      fieldValue:
-          (json['fieldValue'] as String?) ?? (json['value'] as String?) ?? '',
+      fieldValue: _coerceString(
+        json.containsKey('fieldValue')
+            ? json['fieldValue']
+            : (json.containsKey('value') ? json['value'] : ''),
+      ),
       fieldName:
           (json['fieldName'] as String?) ?? fieldObj?['fieldName'] as String?,
       displayName: (json['displayName'] as String?) ??
@@ -24,8 +49,7 @@ class UnitFieldValueModel extends UnitFieldValue {
           (json['fieldType'] as String?) ??
           fieldObj?['fieldTypeId'] as String? ??
           fieldObj?['fieldType'] as String?,
-      isPrimaryFilter: (json['isPrimaryFilter'] as bool?) ??
-          fieldObj?['isPrimaryFilter'] as bool?,
+      isPrimaryFilter: _coerceBool(rawIsPrimary),
     );
   }
 

--- a/control_panel_app/lib/features/admin_units/presentation/widgets/futuristic_unit_card.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/widgets/futuristic_unit_card.dart
@@ -434,10 +434,9 @@ class _FuturisticUnitCardState extends State<FuturisticUnitCard>
   List<Map<String, dynamic>> _getFilterFields() {
     final List<Map<String, dynamic>> filterFields = [];
 
-    // أولوية: الحقول التي isPrimaryFilter = true
+    // أولوية: الحقول التي isPrimaryFilter = true (تُعرض حتى لو كانت القيم فارغة)
     for (final fieldValue in widget.unit.fieldValues) {
-      if (fieldValue.isPrimaryFilter == true &&
-          fieldValue.fieldValue.isNotEmpty) {
+      if (fieldValue.isPrimaryFilter == true) {
         filterFields.add({
           'displayName':
               fieldValue.displayName ?? fieldValue.fieldName ?? 'حقل',
@@ -448,7 +447,7 @@ class _FuturisticUnitCardState extends State<FuturisticUnitCard>
     }
     for (final group in widget.unit.dynamicFields) {
       for (final field in group.fieldValues) {
-        if (field.isPrimaryFilter == true && field.fieldValue.isNotEmpty) {
+        if (field.isPrimaryFilter == true) {
           filterFields.add({
             'displayName': field.displayName ?? field.fieldName ?? 'حقل',
             'value': field.fieldValue,


### PR DESCRIPTION
Ensure dynamic fields with `isPrimaryFilter = true` always display by robustly parsing the flag and rendering them even if their value is empty.

Previously, dynamic fields marked as primary filters were not always visible because the `isPrimaryFilter` flag was not robustly parsed from various API types (e.g., `1`, `0`, `'true'`), and the UI explicitly hid these fields if their `fieldValue` was empty. This PR fixes both issues to ensure all primary filter fields are displayed as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-5eb2c56b-3f2d-4cc3-9af6-14dad47d0bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5eb2c56b-3f2d-4cc3-9af6-14dad47d0bf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

