### PR TITLE
Fix property listing display bug

### DIFF
--- a/control_panel_app/lib/features/admin_properties/presentation/pages/properties_list_page.dart
+++ b/control_panel_app/lib/features/admin_properties/presentation/pages/properties_list_page.dart
@@ -716,8 +716,8 @@ class _PropertiesListPageState extends State<PropertiesListPage>
     return Padding(
       padding: const EdgeInsets.all(16),
       child: GridView.builder(
-        shrinkWrap: true,
-        physics: const NeverScrollableScrollPhysics(),
+        shrinkWrap: false,
+        physics: const BouncingScrollPhysics(),
         gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
           crossAxisCount: crossAxisCount,
           crossAxisSpacing: 16,


### PR DESCRIPTION
Enable scrolling for the properties GridView to display all available properties on the home page.

Previously, the `GridView` was configured with `shrinkWrap: true` and `NeverScrollableScrollPhysics`. When placed within a `SliverFillRemaining`, this setup visually capped the number of displayed properties to a few (appearing as three), preventing users from seeing the full list. This change allows the grid to scroll and render all properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-a63ea691-fbe9-4cde-8e45-b5ab638c1ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a63ea691-fbe9-4cde-8e45-b5ab638c1ac0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

