### PR TITLE
Prevent module deletion with associated bookings or payments

### DIFF
--- a/backend/YemenBooking.Application/Handlers/Commands/Units/DeleteUnitCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Units/DeleteUnitCommandHandler.cs
@@ -70,10 +70,14 @@ namespace YemenBooking.Application.Handlers.Commands.Units
             if (_currentUserService.Role != "Admin" && property.OwnerId != _currentUserService.UserId)
                 return ResultDto<bool>.Failed("غير مصرح لك بحذف هذه الوحدة");
 
-            // التحقق من عدم وجود حجوزات نشطة أو مستقبلية أو مدفوعات مرتبطة بالحجوزات
-            var hasActive = await _unitRepository.CheckActiveBookingsAsync(request.UnitId, cancellationToken);
-            if (hasActive)
-                return ResultDto<bool>.Failed("لا يمكن حذف الوحدة لوجود حجوزات نشطة أو مستقبلية مرتبطة بها");
+            // منع الحذف إذا كان هناك أي حجوزات (بغض النظر عن الحالة) أو أي مدفوعات (حتى وإن كانت مستردة)
+            var hasAnyBookings = await _unitRepository.HasAnyBookingsAsync(request.UnitId, cancellationToken);
+            if (hasAnyBookings)
+                return ResultDto<bool>.Failed("لا يمكن حذف الوحدة لوجود حجوزات مرتبطة بها حتى وإن كانت ملغاة أو سابقة");
+
+            var hasAnyPayments = await _unitRepository.HasAnyPaymentsAsync(request.UnitId, cancellationToken);
+            if (hasAnyPayments)
+                return ResultDto<bool>.Failed("لا يمكن حذف الوحدة لوجود مدفوعات مرتبطة بحجوزاتها حتى وإن كانت مستردة");
 
             // جلب قيم الحقول الديناميكية قبل الحذف
             var dynamicValues = await _valueRepository.GetValuesByUnitIdAsync(request.UnitId, cancellationToken);

--- a/backend/YemenBooking.Core/Interfaces/Repositories/IUnitRepository.cs
+++ b/backend/YemenBooking.Core/Interfaces/Repositories/IUnitRepository.cs
@@ -98,6 +98,18 @@ public interface IUnitRepository : IRepository<Unit>
     Task<bool> CheckActiveBookingsAsync(Guid unitId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// التحقق من وجود أي حجوزات للوحدة (بغض النظر عن الحالة)
+    /// Check if the unit has any bookings regardless of status
+    /// </summary>
+    Task<bool> HasAnyBookingsAsync(Guid unitId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// التحقق من وجود أي مدفوعات مرتبطة بحجوزات هذه الوحدة (حتى وإن كانت مستردة)
+    /// Check if there are any payments associated with bookings of this unit (including refunded)
+    /// </summary>
+    Task<bool> HasAnyPaymentsAsync(Guid unitId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// الحصول على توفر الوحدة
     /// Get unit availability
     /// </summary>

--- a/backend/YemenBooking.Infrastructure/Repositories/UnitRepository.cs
+++ b/backend/YemenBooking.Infrastructure/Repositories/UnitRepository.cs
@@ -104,6 +104,24 @@ namespace YemenBooking.Infrastructure.Repositories
         public async Task<bool> CheckActiveBookingsAsync(Guid unitId, CancellationToken cancellationToken = default)
             => await _context.Bookings.AnyAsync(b => b.UnitId == unitId && b.Status == BookingStatus.Confirmed, cancellationToken);
 
+        /// <summary>
+        /// التحقق من وجود أي حجوزات للوحدة (بغض النظر عن الحالة)
+        /// </summary>
+        public async Task<bool> HasAnyBookingsAsync(Guid unitId, CancellationToken cancellationToken = default)
+        {
+            return await _context.Bookings.AnyAsync(b => b.UnitId == unitId, cancellationToken);
+        }
+
+        /// <summary>
+        /// التحقق من وجود أي مدفوعات مرتبطة بحجوزات هذه الوحدة (حتى وإن كانت مستردة)
+        /// </summary>
+        public async Task<bool> HasAnyPaymentsAsync(Guid unitId, CancellationToken cancellationToken = default)
+        {
+            return await _context.Payments
+                .Include(p => p.Booking)
+                .AnyAsync(p => p.Booking.UnitId == unitId, cancellationToken);
+        }
+
         public async Task<IDictionary<DateTime, bool>> GetUnitAvailabilityAsync(Guid unitId, DateTime fromDate, DateTime toDate, CancellationToken cancellationToken = default)
         {
             var dict = new Dictionary<DateTime, bool>();


### PR DESCRIPTION
Block unit deletion if any bookings (regardless of status) or payments (including refunded) are associated with it.

This implements a stricter business rule to prevent the deletion of units that have any historical or current activity, ensuring data integrity. Previously, only active/future bookings prevented deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1580897-b889-4952-95d3-7dda9f81f5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1580897-b889-4952-95d3-7dda9f81f5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

