### PR TITLE
Fix booking display discrepancy

### DIFF
--- a/control_panel_app/lib/core/enums/booking_status.dart
+++ b/control_panel_app/lib/core/enums/booking_status.dart
@@ -37,3 +37,21 @@ extension BookingStatusExtension on BookingStatus {
     }
   }
 }
+
+extension BookingStatusApi on BookingStatus {
+  /// API enum string expected by backend (no spaces, e.g. "CheckedIn")
+  String get apiValue {
+    switch (this) {
+      case BookingStatus.confirmed:
+        return 'Confirmed';
+      case BookingStatus.pending:
+        return 'Pending';
+      case BookingStatus.cancelled:
+        return 'Cancelled';
+      case BookingStatus.completed:
+        return 'Completed';
+      case BookingStatus.checkedIn:
+        return 'CheckedIn';
+    }
+  }
+}

--- a/control_panel_app/lib/features/admin_bookings/data/datasources/bookings_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_bookings/data/datasources/bookings_remote_datasource.dart
@@ -509,8 +509,9 @@ class BookingsRemoteDataSourceImpl implements BookingsRemoteDataSource {
         if (sortBy != null) 'sortBy': sortBy,
       };
 
+      // Backend route uses path parameter: /api/admin/bookings/property/{propertyId}
       final response = await apiClient.get(
-        '$_baseEndpoint/by-property',
+        '$_baseEndpoint/property/$propertyId',
         queryParameters: queryParams,
       );
 
@@ -543,13 +544,14 @@ class BookingsRemoteDataSourceImpl implements BookingsRemoteDataSource {
   }) async {
     try {
       final queryParams = <String, dynamic>{
-        'status': status.displayNameEn,
+        'status': status.apiValue,
         if (pageNumber != null) 'pageNumber': pageNumber,
         if (pageSize != null) 'pageSize': pageSize,
       };
 
+      // Backend route: /api/admin/bookings/status
       final response = await apiClient.get(
-        '$_baseEndpoint/by-status',
+        '$_baseEndpoint/status',
         queryParameters: queryParams,
       );
 
@@ -591,8 +593,9 @@ class BookingsRemoteDataSourceImpl implements BookingsRemoteDataSource {
         if (pageSize != null) 'pageSize': pageSize,
       };
 
+      // Backend route: /api/admin/bookings/unit/{unitId}
       final response = await apiClient.get(
-        '$_baseEndpoint/by-unit',
+        '$_baseEndpoint/unit/$unitId',
         queryParameters: queryParams,
       );
 
@@ -636,7 +639,7 @@ class BookingsRemoteDataSourceImpl implements BookingsRemoteDataSource {
         'userId': userId,
         if (pageNumber != null) 'pageNumber': pageNumber,
         if (pageSize != null) 'pageSize': pageSize,
-        if (status != null) 'status': status.displayNameEn,
+        if (status != null) 'status': status.apiValue,
         if (guestNameOrEmail != null) 'guestNameOrEmail': guestNameOrEmail,
         if (unitId != null) 'unitId': unitId,
         if (bookingSource != null) 'bookingSource': bookingSource,
@@ -646,8 +649,9 @@ class BookingsRemoteDataSourceImpl implements BookingsRemoteDataSource {
         if (sortBy != null) 'sortBy': sortBy,
       };
 
+      // Backend route: /api/admin/bookings/user/{userId}
       final response = await apiClient.get(
-        '$_baseEndpoint/by-user',
+        '$_baseEndpoint/user/$userId',
         queryParameters: queryParams,
       );
 

--- a/control_panel_app/lib/features/admin_bookings/presentation/pages/bookings_list_page.dart
+++ b/control_panel_app/lib/features/admin_bookings/presentation/pages/bookings_list_page.dart
@@ -539,10 +539,11 @@ class _BookingsListPageState extends State<BookingsListPage>
   void _loadBookings() {
     context.read<BookingsListBloc>().add(
           LoadBookingsEvent(
-            startDate: DateTime.now().subtract(const Duration(days: 30)),
-            endDate: DateTime.now(),
+            // Expand default range to 1 year back to avoid missing older bookings
+            startDate: DateTime.now().subtract(const Duration(days: 365)),
+            endDate: DateTime.now().add(const Duration(days: 1)),
             pageNumber: 1,
-            pageSize: 20,
+            pageSize: 50,
           ),
         );
   }

--- a/control_panel_app/lib/features/admin_bookings/presentation/widgets/booking_filters_widget.dart
+++ b/control_panel_app/lib/features/admin_bookings/presentation/widgets/booking_filters_widget.dart
@@ -392,6 +392,17 @@ class _BookingFiltersWidgetState extends State<BookingFiltersWidget> {
         scrollDirection: Axis.horizontal,
         children: [
           _buildQuickFilterChip(
+            label: 'كل الوقت',
+            isSelected: _filters.startDate == null && _filters.endDate == null,
+            onTap: () {
+              setState(() {
+                _filters = _filters.copyWith(startDate: null, endDate: null);
+              });
+              _applyFilters();
+            },
+            isCompact: isCompact,
+          ),
+          _buildQuickFilterChip(
             label: 'اليوم',
             isSelected: _isToday(),
             onTap: _selectToday,


### PR DESCRIPTION
Fix booking display issues in the admin panel by correcting API endpoint paths, ensuring proper status serialization, and expanding the default date range and page size.

This resolves the problem where only a limited number of bookings (e.g., two cancelled bookings) were visible due to endpoint mismatches, incorrect status value formatting, and a narrow default date range for fetching bookings.

---
<a href="https://cursor.com/background-agent?bcId=bc-2364345e-3eb8-4ad9-89bb-a13a58c53809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2364345e-3eb8-4ad9-89bb-a13a58c53809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

