### PR TITLE
Update property owner registration page design and fields

### DIFF
--- a/control_panel_app/lib/features/auth/presentation/widgets/register_form.dart
+++ b/control_panel_app/lib/features/auth/presentation/widgets/register_form.dart
@@ -21,6 +21,8 @@ import 'package:dio/dio.dart' as dio;
 import '../../../../core/constants/api_constants.dart';
 import '../../../../services/location_service.dart' as loc;
 import 'package:async/async.dart';
+import 'package:bookn_cp_app/features/admin_cities/domain/usecases/get_cities_usecase.dart'
+    as ci_uc;
 
 class RegisterForm extends StatefulWidget {
   final Function(
@@ -86,6 +88,11 @@ class _RegisterFormState extends State<RegisterForm>
   String _selectedPropertyTypeId = '';
   List<ap_models.PropertyTypeModel> _propertyTypes = const [];
   bool _loadingPropertyTypes = false;
+  // Cities dropdown state
+  List<String> _cities = const [];
+  bool _loadingCities = false;
+  String? _selectedCity;
+  String? _citiesError;
   // Places autocomplete
   List<_PlaceSuggestion> _addressSuggestions = const [];
   bool _loadingSuggestions = false;
@@ -132,6 +139,7 @@ class _RegisterFormState extends State<RegisterForm>
     _longitudeFocusNode.addListener(() => setState(() {}));
 
     _loadPropertyTypes();
+    _loadCities();
   }
 
   @override
@@ -344,21 +352,7 @@ class _RegisterFormState extends State<RegisterForm>
           const SizedBox(height: 12),
 
           // City
-          _buildUltraCompactField(
-            controller: _cityController,
-            focusNode: _cityFocusNode,
-            label: 'المدينة',
-            hint: 'صنعاء',
-            icon: Icons.location_city_outlined,
-            textInputAction: TextInputAction.next,
-            onFieldSubmitted: (_) {
-              FocusScope.of(context).requestFocus(_addressFocusNode);
-            },
-            // المدينة اختيارية
-            validator: (value) {
-              return null;
-            },
-          ),
+          _buildCityDropdown(),
 
           const SizedBox(height: 12),
 
@@ -1034,6 +1028,10 @@ class _RegisterFormState extends State<RegisterForm>
         _showFieldError('اسم الكيان مطلوب');
         return;
       }
+      if (_cityController.text.trim().isEmpty) {
+        _showFieldError('المدينة مطلوبة');
+        return;
+      }
       if (_addressController.text.trim().isEmpty) {
         _showFieldError('العنوان مطلوب');
         return;
@@ -1136,6 +1134,137 @@ class _RegisterFormState extends State<RegisterForm>
     } finally {
       setState(() => _loadingPropertyTypes = false);
     }
+  }
+
+  Future<void> _loadCities() async {
+    setState(() {
+      _loadingCities = true;
+      _citiesError = null;
+    });
+    try {
+      final usecase = sl<ci_uc.GetCitiesUseCase>();
+      final result = await usecase(const ci_uc.GetCitiesParams());
+      result.fold(
+        (_) => setState(() {
+          _citiesError = 'تعذر تحميل المدن';
+          _loadingCities = false;
+        }),
+        (list) => setState(() {
+          _cities = list.map((c) => c.name).toList();
+          _loadingCities = false;
+          // لا نعيّن قيمة تلقائياً لإجبار المستخدم على الاختيار والتصديق
+          if (_cities.contains(_cityController.text)) {
+            _selectedCity = _cityController.text;
+          } else {
+            _selectedCity = null;
+            _cityController.text = '';
+          }
+        }),
+      );
+    } catch (_) {
+      setState(() {
+        _citiesError = 'تعذر تحميل المدن';
+        _loadingCities = false;
+      });
+    }
+  }
+
+  Widget _buildCityDropdown() {
+    final isFocused = _cityFocusNode.hasFocus;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      height: 42,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: isFocused
+              ? [
+                  AppTheme.primaryBlue.withValues(alpha: 0.05),
+                  AppTheme.primaryPurple.withValues(alpha: 0.03),
+                ]
+              : [
+                  AppTheme.darkCard.withValues(alpha: 0.2),
+                  AppTheme.darkCard.withValues(alpha: 0.1),
+                ],
+        ),
+        borderRadius: BorderRadius.circular(11),
+        border: Border.all(
+          color: isFocused
+              ? AppTheme.primaryBlue.withValues(alpha: 0.3)
+              : AppTheme.darkBorder.withValues(alpha: 0.1),
+          width: 0.5,
+        ),
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(11),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: DropdownButtonFormField<String?>(
+              value: _cities.contains(_selectedCity) ? _selectedCity : null,
+              dropdownColor: AppTheme.darkCard,
+              style: AppTextStyles.caption.copyWith(
+                color: AppTheme.textWhite.withValues(alpha: 0.9),
+                fontSize: 12,
+              ),
+              icon: Icon(
+                Icons.keyboard_arrow_down_rounded,
+                size: 18,
+                color: AppTheme.textMuted.withValues(alpha: 0.5),
+              ),
+              decoration: InputDecoration(
+                labelText: 'المدينة',
+                labelStyle: AppTextStyles.caption.copyWith(
+                  color: isFocused
+                      ? AppTheme.primaryBlue.withValues(alpha: 0.8)
+                      : AppTheme.textMuted.withValues(alpha: 0.5),
+                  fontSize: 10,
+                ),
+                prefixIcon: Container(
+                  width: 32,
+                  height: 42,
+                  alignment: Alignment.center,
+                  child: Icon(
+                    Icons.location_city_outlined,
+                    color: isFocused
+                        ? AppTheme.primaryBlue.withValues(alpha: 0.7)
+                        : AppTheme.textMuted.withValues(alpha: 0.4),
+                    size: 16,
+                  ),
+                ),
+                border: InputBorder.none,
+                isDense: true,
+              ),
+              items: _loadingCities
+                  ? [
+                      const DropdownMenuItem<String?>(
+                        value: null,
+                        child: Text('جاري تحميل المدن...'),
+                      )
+                    ]
+                  : _cities
+                      .map((c) => DropdownMenuItem<String?>(
+                            value: c,
+                            child: Text(c),
+                          ))
+                      .toList(),
+              onChanged: (v) {
+                setState(() {
+                  _selectedCity = v;
+                  _cityController.text = v ?? '';
+                });
+              },
+              validator: (v) {
+                if ((_cityController.text).trim().isEmpty) {
+                  return 'المدينة مطلوبة';
+                }
+                return null;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
   }
 
   // Places autocomplete

--- a/control_panel_app/lib/features/auth/presentation/widgets/register_form.dart
+++ b/control_panel_app/lib/features/auth/presentation/widgets/register_form.dart
@@ -354,8 +354,8 @@ class _RegisterFormState extends State<RegisterForm>
             onFieldSubmitted: (_) {
               FocusScope.of(context).requestFocus(_addressFocusNode);
             },
+            // المدينة اختيارية
             validator: (value) {
-              if (value == null || value.isEmpty) return 'مطلوب';
               return null;
             },
           ),
@@ -571,40 +571,51 @@ class _RegisterFormState extends State<RegisterForm>
   }
 
   Widget _buildMapPickerButton() {
-    return GestureDetector(
-      onTap: widget.isLoading ? null : _openMapPicker,
-      child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        height: 42,
-        decoration: BoxDecoration(
-          gradient: AppTheme.primaryGradient,
-          borderRadius: BorderRadius.circular(11),
-          border: Border.all(
-            color: AppTheme.primaryBlue.withValues(alpha: 0.3),
-            width: 0.5,
-          ),
-          boxShadow: [
-            BoxShadow(
-              color: AppTheme.primaryBlue.withValues(alpha: 0.15),
-              blurRadius: 10,
-              offset: const Offset(0, 3),
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: widget.isLoading ? null : _openMapPicker,
+        borderRadius: BorderRadius.circular(8),
+        child: Ink(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [
+                AppTheme.primaryBlue.withValues(alpha: 0.8),
+                AppTheme.primaryBlue.withValues(alpha: 0.6),
+              ],
             ),
-          ],
-        ),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Icon(Icons.map_rounded, color: Colors.white, size: 16),
-            const SizedBox(width: 6),
-            Text(
-              'تحديد الموقع على الخريطة',
-              style: AppTextStyles.caption.copyWith(
-                color: Colors.white,
-                fontSize: 12,
-                fontWeight: FontWeight.w600,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              BoxShadow(
+                color: AppTheme.primaryBlue.withValues(alpha: 0.2),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
               ),
+            ],
+          ),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(
+                  Icons.map_rounded,
+                  size: 16,
+                  color: Colors.white,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  'تحديد على الخريطة',
+                  style: AppTextStyles.caption.copyWith(
+                    color: Colors.white,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       ),
     );
@@ -1021,10 +1032,6 @@ class _RegisterFormState extends State<RegisterForm>
       }
       if (_propertyNameController.text.trim().isEmpty) {
         _showFieldError('اسم الكيان مطلوب');
-        return;
-      }
-      if (_cityController.text.trim().isEmpty) {
-        _showFieldError('المدينة مطلوبة');
         return;
       }
       if (_addressController.text.trim().isEmpty) {


### PR DESCRIPTION
Make the city field optional and standardize the map selection button style in the owner registration form.

The city field was made optional to align with its status in the property creation page, and the map button style was updated for UI consistency with the units filter map button. No changes were needed for the price field as it was not present, and backend modifications were not applicable for owner registration.

---
<a href="https://cursor.com/background-agent?bcId=bc-b73c59e2-54b6-4aec-8171-613d56117242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b73c59e2-54b6-4aec-8171-613d56117242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

