### PR TITLE
Fix profile image upload and display issue

### DIFF
--- a/backend/YemenBooking.Application/Handlers/Commands/MobileApp/Auth/ClientUpdateUserProfileCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/MobileApp/Auth/ClientUpdateUserProfileCommandHandler.cs
@@ -68,7 +68,7 @@ public class ClientUpdateUserProfileCommandHandler : IRequestHandler<ClientUpdat
 
             // حفظ التغييرات
             user.UpdatedAt = DateTime.UtcNow;
-            await _userRepository.UpdateAsync(user, cancellationToken);
+            await _userRepository.UpdateUserAsync(user, cancellationToken);
 
             _logger.LogInformation("تم تحديث الملف الشخصي بنجاح للمستخدم: {UserId}", request.UserId);
 

--- a/backend/YemenBooking.Application/Handlers/Commands/MobileApp/Auth/UpdateUserProfileCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/MobileApp/Auth/UpdateUserProfileCommandHandler.cs
@@ -172,7 +172,7 @@ public class UpdateUserProfileCommandHandler : IRequestHandler<UpdateUserProfile
             if (hasChanges)
             {
                 user.UpdatedAt = DateTime.UtcNow;
-                await _userRepository.UpdateAsync(user, cancellationToken);
+                await _userRepository.UpdateUserAsync(user, cancellationToken);
                 
                 _logger.LogInformation("تم حفظ تحديثات الملف الشخصي بنجاح للمستخدم: {UserId}", request.UserId);
 

--- a/backend/YemenBooking.Application/Handlers/Commands/MobileApp/Auth/UploadUserProfileImageCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/MobileApp/Auth/UploadUserProfileImageCommandHandler.cs
@@ -57,7 +57,7 @@ namespace YemenBooking.Application.Handlers.Commands.MobileApp.Auth
 
                 user.ProfileImageUrl = imageUrl;
                 user.UpdatedAt = DateTime.UtcNow;
-                await _userRepository.UpdateAsync(user, cancellationToken);
+                await _userRepository.UpdateUserAsync(user, cancellationToken);
 
                 var response = new UploadUserProfileImageResponse
                 {


### PR DESCRIPTION
Fix profile image not persisting after upload by switching to a repository method that saves changes to the database.

The `IRepository.UpdateAsync` method, used in `UploadUserProfileImageCommandHandler`, `UpdateUserProfileCommandHandler`, and `ClientUpdateUserProfileCommandHandler`, did not trigger an immediate save to the database. This meant that although the `ProfileImageUrl` was updated in the entity, the change was not persisted, causing the `profileImage` to appear empty on subsequent fetches or after re-login. The fix involves using `IUserRepository.UpdateUserAsync`, which correctly saves the updated user entity.

---
<a href="https://cursor.com/background-agent?bcId=bc-eadc72d7-d392-4dae-9933-7bf525b824b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eadc72d7-d392-4dae-9933-7bf525b824b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

