### PR TITLE
Investigate and fix thumbnail display issue

### DIFF
--- a/backend/YemenBooking.Api/Controllers/Images/ImagesController.cs
+++ b/backend/YemenBooking.Api/Controllers/Images/ImagesController.cs
@@ -76,6 +76,20 @@ namespace YemenBooking.Api.Controllers.Images
             {
                 image.Url = baseUrl + (image.Url.StartsWith("/") ? image.Url : "/" + image.Url);
             }
+            // Ensure absolute URLs for thumbnails and video thumbnail if present
+            if (image.Thumbnails != null)
+            {
+                image.Thumbnails.Small = string.IsNullOrWhiteSpace(image.Thumbnails.Small) ? image.Thumbnails.Small : (image.Thumbnails.Small.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? image.Thumbnails.Small : baseUrl + (image.Thumbnails.Small.StartsWith("/") ? image.Thumbnails.Small : "/" + image.Thumbnails.Small));
+                image.Thumbnails.Medium = string.IsNullOrWhiteSpace(image.Thumbnails.Medium) ? image.Thumbnails.Medium : (image.Thumbnails.Medium.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? image.Thumbnails.Medium : baseUrl + (image.Thumbnails.Medium.StartsWith("/") ? image.Thumbnails.Medium : "/" + image.Thumbnails.Medium));
+                image.Thumbnails.Large = string.IsNullOrWhiteSpace(image.Thumbnails.Large) ? image.Thumbnails.Large : (image.Thumbnails.Large.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? image.Thumbnails.Large : baseUrl + (image.Thumbnails.Large.StartsWith("/") ? image.Thumbnails.Large : "/" + image.Thumbnails.Large));
+                image.Thumbnails.Hd = string.IsNullOrWhiteSpace(image.Thumbnails.Hd) ? image.Thumbnails.Hd : (image.Thumbnails.Hd.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? image.Thumbnails.Hd : baseUrl + (image.Thumbnails.Hd.StartsWith("/") ? image.Thumbnails.Hd : "/" + image.Thumbnails.Hd));
+            }
+            if (!string.IsNullOrWhiteSpace(image.VideoThumbnail))
+            {
+                image.VideoThumbnail = image.VideoThumbnail!.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                    ? image.VideoThumbnail
+                    : baseUrl + (image.VideoThumbnail!.StartsWith("/") ? image.VideoThumbnail : "/" + image.VideoThumbnail);
+            }
             
             return Ok(new { success = true, taskId = image.Id, image });
         }
@@ -98,6 +112,11 @@ namespace YemenBooking.Api.Controllers.Images
                 // Ensure absolute Url for the main image
                 if (!img.Url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
                     img.Url = baseUrl + (img.Url.StartsWith("/") ? img.Url : "/" + img.Url);
+                // Ensure absolute Url for video thumbnail if present
+                if (!string.IsNullOrWhiteSpace(img.VideoThumbnail) && !img.VideoThumbnail!.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    img.VideoThumbnail = baseUrl + (img.VideoThumbnail!.StartsWith("/") ? img.VideoThumbnail : "/" + img.VideoThumbnail);
+                }
                 // Only generate thumbnails if the DTO provided a thumbnail path
                 if (img.Thumbnails != null && !string.IsNullOrEmpty(img.Thumbnails.Small))
                 {
@@ -109,10 +128,10 @@ namespace YemenBooking.Api.Controllers.Images
                     var ext = Path.GetExtension(path);
                     var thumbRelative = folder + "/" + fileName + "_thumb" + ext;
                     var thumbUrl = baseUrl + (thumbRelative.StartsWith("/") ? thumbRelative : "/" + thumbRelative);
-                    img.Thumbnails.Small = baseUrl + (img.Thumbnails.Small.StartsWith("/") ? img.Thumbnails.Small : "/" + img.Thumbnails.Small);
-                    img.Thumbnails.Medium = baseUrl + (img.Thumbnails.Medium.StartsWith("/") ? img.Thumbnails.Medium : "/" + img.Thumbnails.Medium);
-                    img.Thumbnails.Large = baseUrl + (img.Thumbnails.Large.StartsWith("/") ? img.Thumbnails.Large : "/" + img.Thumbnails.Large);
-                    img.Thumbnails.Hd = baseUrl + (img.Thumbnails.Hd.StartsWith("/") ? img.Thumbnails.Hd : "/" + img.Thumbnails.Hd);
+                    img.Thumbnails.Small = string.IsNullOrWhiteSpace(img.Thumbnails.Small) ? img.Thumbnails.Small : (img.Thumbnails.Small.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? img.Thumbnails.Small : baseUrl + (img.Thumbnails.Small.StartsWith("/") ? img.Thumbnails.Small : "/" + img.Thumbnails.Small));
+                    img.Thumbnails.Medium = string.IsNullOrWhiteSpace(img.Thumbnails.Medium) ? img.Thumbnails.Medium : (img.Thumbnails.Medium.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? img.Thumbnails.Medium : baseUrl + (img.Thumbnails.Medium.StartsWith("/") ? img.Thumbnails.Medium : "/" + img.Thumbnails.Medium));
+                    img.Thumbnails.Large = string.IsNullOrWhiteSpace(img.Thumbnails.Large) ? img.Thumbnails.Large : (img.Thumbnails.Large.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? img.Thumbnails.Large : baseUrl + (img.Thumbnails.Large.StartsWith("/") ? img.Thumbnails.Large : "/" + img.Thumbnails.Large));
+                    img.Thumbnails.Hd = string.IsNullOrWhiteSpace(img.Thumbnails.Hd) ? img.Thumbnails.Hd : (img.Thumbnails.Hd.StartsWith("http", StringComparison.OrdinalIgnoreCase) ? img.Thumbnails.Hd : baseUrl + (img.Thumbnails.Hd.StartsWith("/") ? img.Thumbnails.Hd : "/" + img.Thumbnails.Hd));
                 }
             }
             return Ok(new

--- a/backend/YemenBooking.Api/Program.cs
+++ b/backend/YemenBooking.Api/Program.cs
@@ -126,6 +126,10 @@ builder.Services.AddControllers(options =>
         options.JsonSerializerOptions.PropertyNameCaseInsensitive = true;
     });
 
+// Bind file storage settings so URLs are absolute and paths are correct
+builder.Services.Configure<YemenBooking.Infrastructure.Settings.FileStorageSettings>(
+    builder.Configuration.GetSection("FileStorageSettings"));
+
 // إضافة سياسة CORS للسماح بالاتصالات من الواجهة الأمامية
 builder.Services.AddCors(options =>
 {


### PR DESCRIPTION
Normalize video and image thumbnail URLs to absolute paths in API responses and bind file storage settings to fix missing media display in the Flutter app.

The backend was generating relative URLs for video thumbnails and various image thumbnail sizes, which the Flutter application could not resolve correctly, leading to missing media display. This PR ensures all media-related URLs in the API responses are absolute and binds `FileStorageSettings` to allow the backend to properly construct these paths using the configured base URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-132e86d4-160f-496a-a8a8-b2cb976fce0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-132e86d4-160f-496a-a8a8-b2cb976fce0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

