### PR TITLE
Refactor: Use FFMpegCore for media processing

### DIFF
--- a/backend/YemenBooking.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/backend/YemenBooking.Api/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using YemenBooking.Infrastructure.UnitOfWork;
 using YemenBooking.Core.Interfaces;
 using FluentValidation;
 using MediatR;
+using FFMpegCore;
 
 namespace YemenBooking.Api.Extensions
 {
@@ -39,6 +40,23 @@ namespace YemenBooking.Api.Extensions
             // Register media metadata and thumbnail services
             services.AddScoped<IMediaMetadataService, MediaMetadataService>();
             services.AddScoped<IMediaThumbnailService, MediaThumbnailService>();
+            // Configure FFMpegCore global options (optional: set custom binaries path from env)
+            var ffmpegPath = Environment.GetEnvironmentVariable("FFMPEG_PATH");
+            var ffprobePath = Environment.GetEnvironmentVariable("FFPROBE_PATH");
+            if (!string.IsNullOrWhiteSpace(ffmpegPath))
+            {
+                GlobalFFOptions.Configure(options =>
+                {
+                    options.BinaryFolder = System.IO.Path.GetDirectoryName(ffmpegPath);
+                    options.TemporaryFilesFolder = System.IO.Path.GetTempPath();
+                });
+                FFmpeg.SetExecutablesPath(System.IO.Path.GetDirectoryName(ffmpegPath)!);
+            }
+            else if (!string.IsNullOrWhiteSpace(ffprobePath))
+            {
+                GlobalFFOptions.Configure(options => { options.TemporaryFilesFolder = System.IO.Path.GetTempPath(); });
+                FFmpeg.SetExecutablesPath(System.IO.Path.GetDirectoryName(ffprobePath)!);
+            }
             // Register currency ensure service
             services.AddScoped<ICurrencyEnsureService, CurrencyEnsureService>();
 

--- a/backend/YemenBooking.Infrastructure/Services/MediaThumbnailService.cs
+++ b/backend/YemenBooking.Infrastructure/Services/MediaThumbnailService.cs
@@ -1,10 +1,11 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using YemenBooking.Application.Interfaces.Services;
+using FFMpegCore;
+using FFMpegCore.Pipes;
 
 namespace YemenBooking.Infrastructure.Services
 {
@@ -14,12 +15,9 @@ namespace YemenBooking.Infrastructure.Services
     public class MediaThumbnailService : IMediaThumbnailService
     {
         private readonly ILogger<MediaThumbnailService> _logger;
-        private readonly string _ffmpegPath;
-
         public MediaThumbnailService(ILogger<MediaThumbnailService> logger)
         {
             _logger = logger;
-            _ffmpegPath = Environment.GetEnvironmentVariable("FFMPEG_PATH")?.Trim() ?? "ffmpeg";
         }
 
         public Task<byte[]?> TryGenerateThumbnailAsync(string videoFilePath, CancellationToken cancellationToken)
@@ -28,14 +26,21 @@ namespace YemenBooking.Infrastructure.Services
             {
                 if (!File.Exists(videoFilePath)) return Task.FromResult<byte[]?>(null);
 
-                // جرّب عدة نقاط زمنية لاستخراج إطار صالح (لبعض الفيديوهات القصيرة قد تفشل ثانية 1)
+                // جرّب عدة نقاط زمنية لاستخراج إطار صالح باستخدام FFMpegCore
                 var probeOffsets = new[] { 0.1, 1.0, 3.0 };
                 foreach (var seconds in probeOffsets)
                 {
-                    var thumb = TryGenerateAtOffset(videoFilePath, seconds);
-                    if (thumb != null && thumb.Length > 0)
+                    try
                     {
-                        return Task.FromResult<byte[]?>(thumb);
+                        var frame = FFMpeg.Snapshot(videoFilePath, TimeSpan.FromSeconds(seconds));
+                        if (frame != null && frame.Length > 0)
+                        {
+                            return Task.FromResult<byte[]?>(frame);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "FFMpegCore snapshot failed at {Offset}s", seconds);
                     }
                 }
                 return Task.FromResult<byte[]?>(null);
@@ -44,48 +49,6 @@ namespace YemenBooking.Infrastructure.Services
             {
                 _logger.LogDebug(ex, "Error generating thumbnail using ffmpeg");
                 return Task.FromResult<byte[]?>(null);
-            }
-        }
-
-        private byte[]? TryGenerateAtOffset(string videoFilePath, double seconds)
-        {
-            try
-            {
-                var tempJpg = Path.Combine(Path.GetTempPath(), $"thumb_{Guid.NewGuid():N}.jpg");
-                // ضع -ss قبل -i للـ fast-seek. استخدم دقة موثوقة للقيم الصغيرة
-                var ts = TimeSpan.FromSeconds(seconds);
-                var hh = ts.Hours.ToString().PadLeft(2, '0');
-                var mm = ts.Minutes.ToString().PadLeft(2, '0');
-                var ss = ts.Seconds.ToString().PadLeft(2, '0');
-                var ms = ts.Milliseconds.ToString().PadLeft(3, '0');
-                var offset = $"{hh}:{mm}:{ss}.{ms}";
-                var args = $"-y -ss {offset} -i \"{videoFilePath}\" -frames:v 1 -q:v 2 \"{tempJpg}\"";
-                var psi = new ProcessStartInfo
-                {
-                    FileName = _ffmpegPath,
-                    Arguments = args,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                };
-                using var proc = new Process { StartInfo = psi };
-                proc.Start();
-                proc.WaitForExit();
-                if (proc.ExitCode != 0 || !File.Exists(tempJpg))
-                {
-                    var err = proc.StandardError.ReadToEnd();
-                    _logger.LogDebug("ffmpeg failed at {Offset}s: {Err}", seconds, err);
-                    return null;
-                }
-                var bytes = File.ReadAllBytes(tempJpg);
-                try { File.Delete(tempJpg); } catch { /* ignore */ }
-                return bytes;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "ffmpeg thumbnail gen error at {Offset}s", seconds);
-                return null;
             }
         }
     }

--- a/backend/YemenBooking.Infrastructure/YemenBooking.Infrastructure.csproj
+++ b/backend/YemenBooking.Infrastructure/YemenBooking.Infrastructure.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="QuestPDF" Version="2023.12.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="FFMpegCore" Version="5.1.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Replaces direct ffprobe calls with FFMpegCore library for duration and thumbnail generation.