### PR TITLE
Create property and unit image management for admin sections

### DIFF
--- a/control_panel_app/lib/features/admin_sections/data/repositories/property_in_section_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_sections/data/repositories/property_in_section_images_repository_impl.dart
@@ -1,0 +1,177 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/section_image.dart';
+import '../../domain/repositories/property_in_section_images_repository.dart';
+import '../datasources/property_in_section_images_remote_datasource.dart';
+import '../models/section_image_model.dart';
+
+class PropertyInSectionImagesRepositoryImpl implements PropertyInSectionImagesRepository {
+  final PropertyInSectionImagesRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  PropertyInSectionImagesRepositoryImpl({required this.remoteDataSource, required this.networkInfo});
+
+  @override
+  Future<Either<Failure, SectionImage>> uploadImage({
+    required String propertyInSectionId,
+    required String filePath,
+    String? category,
+    String? alt,
+    bool isPrimary = false,
+    int? order,
+    List<String>? tags,
+    ProgressCallback? onSendProgress,
+  }) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final SectionImageModel result = await remoteDataSource.uploadImage(
+          propertyInSectionId: propertyInSectionId,
+          filePath: filePath,
+          category: category,
+          alt: alt,
+          isPrimary: isPrimary,
+          order: order,
+          tags: tags,
+          onSendProgress: onSendProgress,
+        );
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionImage>>> getImages(String propertyInSectionId, {int? page, int? limit}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final List<SectionImageModel> result = await remoteDataSource.getImages(propertyInSectionId, page: page, limit: limit);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.updateImage(imageId, data);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteImage(String propertyInSectionId, String imageId, {bool permanent = false}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.deleteImage(propertyInSectionId, imageId, permanent: permanent);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> reorderImages(String propertyInSectionId, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.reorderImages(propertyInSectionId, imageIds);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> setAsPrimaryImage(String propertyInSectionId, String imageId) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.setAsPrimaryImage(propertyInSectionId, imageId);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
+    required String propertyInSectionId,
+    required List<String> filePaths,
+    String? category,
+    List<String>? tags,
+    void Function(String filePath, int sent, int total)? onProgress,
+  }) async {
+    if (await networkInfo.isConnected) {
+      final uploaded = <SectionImage>[];
+      for (final path in filePaths) {
+        final res = await uploadImage(
+          propertyInSectionId: propertyInSectionId,
+          filePath: path,
+          category: category,
+          tags: tags,
+          onSendProgress: (sent, total) => onProgress?.call(path, sent, total),
+        );
+        res.fold((_) {}, (img) => uploaded.add(img));
+      }
+      return Right(uploaded);
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteMultipleImages(String propertyInSectionId, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        var ok = true;
+        for (final id in imageIds) {
+          final res = await deleteImage(propertyInSectionId, id);
+          res.fold((_) => ok = false, (_) {});
+        }
+        return Right(ok);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+}
+

--- a/control_panel_app/lib/features/admin_sections/data/repositories/unit_in_section_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_sections/data/repositories/unit_in_section_images_repository_impl.dart
@@ -1,0 +1,177 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/section_image.dart';
+import '../../domain/repositories/unit_in_section_images_repository.dart';
+import '../datasources/unit_in_section_images_remote_datasource.dart';
+import '../models/section_image_model.dart';
+
+class UnitInSectionImagesRepositoryImpl implements UnitInSectionImagesRepository {
+  final UnitInSectionImagesRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  UnitInSectionImagesRepositoryImpl({required this.remoteDataSource, required this.networkInfo});
+
+  @override
+  Future<Either<Failure, SectionImage>> uploadImage({
+    required String unitInSectionId,
+    required String filePath,
+    String? category,
+    String? alt,
+    bool isPrimary = false,
+    int? order,
+    List<String>? tags,
+    ProgressCallback? onSendProgress,
+  }) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final SectionImageModel result = await remoteDataSource.uploadImage(
+          unitInSectionId: unitInSectionId,
+          filePath: filePath,
+          category: category,
+          alt: alt,
+          isPrimary: isPrimary,
+          order: order,
+          tags: tags,
+          onSendProgress: onSendProgress,
+        );
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionImage>>> getImages(String unitInSectionId, {int? page, int? limit}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final List<SectionImageModel> result = await remoteDataSource.getImages(unitInSectionId, page: page, limit: limit);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.updateImage(imageId, data);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteImage(String unitInSectionId, String imageId, {bool permanent = false}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.deleteImage(unitInSectionId, imageId, permanent: permanent);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> reorderImages(String unitInSectionId, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.reorderImages(unitInSectionId, imageIds);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> setAsPrimaryImage(String unitInSectionId, String imageId) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.setAsPrimaryImage(unitInSectionId, imageId);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
+    required String unitInSectionId,
+    required List<String> filePaths,
+    String? category,
+    List<String>? tags,
+    void Function(String filePath, int sent, int total)? onProgress,
+  }) async {
+    if (await networkInfo.isConnected) {
+      final uploaded = <SectionImage>[];
+      for (final path in filePaths) {
+        final res = await uploadImage(
+          unitInSectionId: unitInSectionId,
+          filePath: path,
+          category: category,
+          tags: tags,
+          onSendProgress: (sent, total) => onProgress?.call(path, sent, total),
+        );
+        res.fold((_) {}, (img) => uploaded.add(img));
+      }
+      return Right(uploaded);
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteMultipleImages(String unitInSectionId, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        var ok = true;
+        for (final id in imageIds) {
+          final res = await deleteImage(unitInSectionId, id);
+          res.fold((_) => ok = false, (_) {});
+        }
+        return Right(ok);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+}
+

--- a/control_panel_app/lib/features/admin_sections/domain/repositories/property_in_section_images_repository.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/repositories/property_in_section_images_repository.dart
@@ -1,0 +1,38 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/error/failures.dart';
+import '../../entities/section_image.dart';
+
+abstract class PropertyInSectionImagesRepository {
+  Future<Either<Failure, SectionImage>> uploadImage({
+    required String propertyInSectionId,
+    required String filePath,
+    String? category,
+    String? alt,
+    bool isPrimary,
+    int? order,
+    List<String>? tags,
+    ProgressCallback? onSendProgress,
+  });
+
+  Future<Either<Failure, List<SectionImage>>> getImages(String propertyInSectionId, {int? page, int? limit});
+
+  Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data);
+
+  Future<Either<Failure, bool>> deleteImage(String propertyInSectionId, String imageId, {bool permanent});
+
+  Future<Either<Failure, bool>> reorderImages(String propertyInSectionId, List<String> imageIds);
+
+  Future<Either<Failure, bool>> setAsPrimaryImage(String propertyInSectionId, String imageId);
+
+  Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
+    required String propertyInSectionId,
+    required List<String> filePaths,
+    String? category,
+    List<String>? tags,
+    void Function(String filePath, int sent, int total)? onProgress,
+  });
+
+  Future<Either<Failure, bool>> deleteMultipleImages(String propertyInSectionId, List<String> imageIds);
+}
+

--- a/control_panel_app/lib/features/admin_sections/domain/repositories/unit_in_section_images_repository.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/repositories/unit_in_section_images_repository.dart
@@ -1,0 +1,38 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/error/failures.dart';
+import '../../entities/section_image.dart';
+
+abstract class UnitInSectionImagesRepository {
+  Future<Either<Failure, SectionImage>> uploadImage({
+    required String unitInSectionId,
+    required String filePath,
+    String? category,
+    String? alt,
+    bool isPrimary,
+    int? order,
+    List<String>? tags,
+    ProgressCallback? onSendProgress,
+  });
+
+  Future<Either<Failure, List<SectionImage>>> getImages(String unitInSectionId, {int? page, int? limit});
+
+  Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data);
+
+  Future<Either<Failure, bool>> deleteImage(String unitInSectionId, String imageId, {bool permanent});
+
+  Future<Either<Failure, bool>> reorderImages(String unitInSectionId, List<String> imageIds);
+
+  Future<Either<Failure, bool>> setAsPrimaryImage(String unitInSectionId, String imageId);
+
+  Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
+    required String unitInSectionId,
+    required List<String> filePaths,
+    String? category,
+    List<String>? tags,
+    void Function(String filePath, int sent, int total)? onProgress,
+  });
+
+  Future<Either<Failure, bool>> deleteMultipleImages(String unitInSectionId, List<String> imageIds);
+}
+

--- a/control_panel_app/lib/features/admin_sections/domain/usecases/property_in_section_images/usecases.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/usecases/property_in_section_images/usecases.dart
@@ -1,0 +1,62 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../entities/section_image.dart';
+import '../../repositories/property_in_section_images_repository.dart';
+import '../../../../core/error/failures.dart';
+
+class UploadPropertyInSectionImageParams {
+  final String propertyInSectionId;
+  final String filePath;
+  final String? category;
+  final String? alt;
+  final bool isPrimary;
+  final int? order;
+  final List<String>? tags;
+  final ProgressCallback? onSendProgress;
+  UploadPropertyInSectionImageParams({
+    required this.propertyInSectionId,
+    required this.filePath,
+    this.category,
+    this.alt,
+    this.isPrimary = false,
+    this.order,
+    this.tags,
+    this.onSendProgress,
+  });
+}
+
+class UploadPropertyInSectionImageUseCase {
+  final PropertyInSectionImagesRepository repo;
+  UploadPropertyInSectionImageUseCase(this.repo);
+  Future<Either<Failure, SectionImage>> call(UploadPropertyInSectionImageParams p) =>
+      repo.uploadImage(
+        propertyInSectionId: p.propertyInSectionId,
+        filePath: p.filePath,
+        category: p.category,
+        alt: p.alt,
+        isPrimary: p.isPrimary,
+        order: p.order,
+        tags: p.tags,
+        onSendProgress: p.onSendProgress,
+      );
+}
+
+class GetPropertyInSectionImagesParams { final String propertyInSectionId; final int? page; final int? limit; GetPropertyInSectionImagesParams({required this.propertyInSectionId, this.page, this.limit}); }
+class GetPropertyInSectionImagesUseCase { final PropertyInSectionImagesRepository repo; GetPropertyInSectionImagesUseCase(this.repo); Future<Either<Failure, List<SectionImage>>> call(GetPropertyInSectionImagesParams p)=> repo.getImages(p.propertyInSectionId, page: p.page, limit: p.limit); }
+
+class UpdatePropertyInSectionImageParams { final String imageId; final Map<String,dynamic> data; UpdatePropertyInSectionImageParams(this.imageId, this.data); }
+class UpdatePropertyInSectionImageUseCase { final PropertyInSectionImagesRepository repo; UpdatePropertyInSectionImageUseCase(this.repo); Future<Either<Failure,bool>> call(UpdatePropertyInSectionImageParams p)=> repo.updateImage(p.imageId, p.data); }
+
+class DeletePropertyInSectionImageUseCase { final PropertyInSectionImagesRepository repo; DeletePropertyInSectionImageUseCase(this.repo); Future<Either<Failure,bool>> call(String propertyInSectionId,String imageId,{bool permanent=false})=> repo.deleteImage(propertyInSectionId, imageId, permanent: permanent); }
+
+class ReorderPropertyInSectionImagesParams { final String propertyInSectionId; final List<String> imageIds; ReorderPropertyInSectionImagesParams(this.propertyInSectionId, this.imageIds); }
+class ReorderPropertyInSectionImagesUseCase { final PropertyInSectionImagesRepository repo; ReorderPropertyInSectionImagesUseCase(this.repo); Future<Either<Failure,bool>> call(ReorderPropertyInSectionImagesParams p)=> repo.reorderImages(p.propertyInSectionId, p.imageIds); }
+
+class SetPrimaryPropertyInSectionImageParams { final String propertyInSectionId; final String imageId; SetPrimaryPropertyInSectionImageParams(this.propertyInSectionId, this.imageId); }
+class SetPrimaryPropertyInSectionImageUseCase { final PropertyInSectionImagesRepository repo; SetPrimaryPropertyInSectionImageUseCase(this.repo); Future<Either<Failure,bool>> call(SetPrimaryPropertyInSectionImageParams p)=> repo.setAsPrimaryImage(p.propertyInSectionId, p.imageId); }
+
+class UploadMultiplePropertyInSectionImagesParams { final String propertyInSectionId; final List<String> filePaths; final String? category; final List<String>? tags; final void Function(String,int,int)? onProgress; UploadMultiplePropertyInSectionImagesParams({required this.propertyInSectionId, required this.filePaths, this.category, this.tags, this.onProgress}); }
+class UploadMultiplePropertyInSectionImagesUseCase { final PropertyInSectionImagesRepository repo; UploadMultiplePropertyInSectionImagesUseCase(this.repo); Future<Either<Failure,List<SectionImage>>> call(UploadMultiplePropertyInSectionImagesParams p)=> repo.uploadMultipleImages(propertyInSectionId: p.propertyInSectionId, filePaths: p.filePaths, category: p.category, tags: p.tags, onProgress: p.onProgress); }
+
+class DeleteMultiplePropertyInSectionImagesUseCase { final PropertyInSectionImagesRepository repo; DeleteMultiplePropertyInSectionImagesUseCase(this.repo); Future<Either<Failure,bool>> call(String propertyInSectionId,List<String> imageIds)=> repo.deleteMultipleImages(propertyInSectionId, imageIds); }
+

--- a/control_panel_app/lib/features/admin_sections/domain/usecases/unit_in_section_images/usecases.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/usecases/unit_in_section_images/usecases.dart
@@ -1,0 +1,62 @@
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../entities/section_image.dart';
+import '../../repositories/unit_in_section_images_repository.dart';
+import '../../../../core/error/failures.dart';
+
+class UploadUnitInSectionImageParams {
+  final String unitInSectionId;
+  final String filePath;
+  final String? category;
+  final String? alt;
+  final bool isPrimary;
+  final int? order;
+  final List<String>? tags;
+  final ProgressCallback? onSendProgress;
+  UploadUnitInSectionImageParams({
+    required this.unitInSectionId,
+    required this.filePath,
+    this.category,
+    this.alt,
+    this.isPrimary = false,
+    this.order,
+    this.tags,
+    this.onSendProgress,
+  });
+}
+
+class UploadUnitInSectionImageUseCase {
+  final UnitInSectionImagesRepository repo;
+  UploadUnitInSectionImageUseCase(this.repo);
+  Future<Either<Failure, SectionImage>> call(UploadUnitInSectionImageParams p) =>
+      repo.uploadImage(
+        unitInSectionId: p.unitInSectionId,
+        filePath: p.filePath,
+        category: p.category,
+        alt: p.alt,
+        isPrimary: p.isPrimary,
+        order: p.order,
+        tags: p.tags,
+        onSendProgress: p.onSendProgress,
+      );
+}
+
+class GetUnitInSectionImagesParams { final String unitInSectionId; final int? page; final int? limit; GetUnitInSectionImagesParams({required this.unitInSectionId, this.page, this.limit}); }
+class GetUnitInSectionImagesUseCase { final UnitInSectionImagesRepository repo; GetUnitInSectionImagesUseCase(this.repo); Future<Either<Failure, List<SectionImage>>> call(GetUnitInSectionImagesParams p)=> repo.getImages(p.unitInSectionId, page: p.page, limit: p.limit); }
+
+class UpdateUnitInSectionImageParams { final String imageId; final Map<String,dynamic> data; UpdateUnitInSectionImageParams(this.imageId, this.data); }
+class UpdateUnitInSectionImageUseCase { final UnitInSectionImagesRepository repo; UpdateUnitInSectionImageUseCase(this.repo); Future<Either<Failure,bool>> call(UpdateUnitInSectionImageParams p)=> repo.updateImage(p.imageId, p.data); }
+
+class DeleteUnitInSectionImageUseCase { final UnitInSectionImagesRepository repo; DeleteUnitInSectionImageUseCase(this.repo); Future<Either<Failure,bool>> call(String unitInSectionId,String imageId,{bool permanent=false})=> repo.deleteImage(unitInSectionId, imageId, permanent: permanent); }
+
+class ReorderUnitInSectionImagesParams { final String unitInSectionId; final List<String> imageIds; ReorderUnitInSectionImagesParams(this.unitInSectionId, this.imageIds); }
+class ReorderUnitInSectionImagesUseCase { final UnitInSectionImagesRepository repo; ReorderUnitInSectionImagesUseCase(this.repo); Future<Either<Failure,bool>> call(ReorderUnitInSectionImagesParams p)=> repo.reorderImages(p.unitInSectionId, p.imageIds); }
+
+class SetPrimaryUnitInSectionImageParams { final String unitInSectionId; final String imageId; SetPrimaryUnitInSectionImageParams(this.unitInSectionId, this.imageId); }
+class SetPrimaryUnitInSectionImageUseCase { final UnitInSectionImagesRepository repo; SetPrimaryUnitInSectionImageUseCase(this.repo); Future<Either<Failure,bool>> call(SetPrimaryUnitInSectionImageParams p)=> repo.setAsPrimaryImage(p.unitInSectionId, p.imageId); }
+
+class UploadMultipleUnitInSectionImagesParams { final String unitInSectionId; final List<String> filePaths; final String? category; final List<String>? tags; final void Function(String,int,int)? onProgress; UploadMultipleUnitInSectionImagesParams({required this.unitInSectionId, required this.filePaths, this.category, this.tags, this.onProgress}); }
+class UploadMultipleUnitInSectionImagesUseCase { final UnitInSectionImagesRepository repo; UploadMultipleUnitInSectionImagesUseCase(this.repo); Future<Either<Failure,List<SectionImage>>> call(UploadMultipleUnitInSectionImagesParams p)=> repo.uploadMultipleImages(unitInSectionId: p.unitInSectionId, filePaths: p.filePaths, category: p.category, tags: p.tags, onProgress: p.onProgress); }
+
+class DeleteMultipleUnitInSectionImagesUseCase { final UnitInSectionImagesRepository repo; DeleteMultipleUnitInSectionImagesUseCase(this.repo); Future<Either<Failure,bool>> call(String unitInSectionId,List<String> imageIds)=> repo.deleteMultipleImages(unitInSectionId, imageIds); }
+

--- a/control_panel_app/lib/features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_bloc.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failures.dart';
+import '../../../domain/entities/section_image.dart';
+import '../../../domain/usecases/property_in_section_images/usecases.dart';
+import 'property_in_section_images_event.dart';
+import 'property_in_section_images_state.dart';
+
+class PropertyInSectionImagesBloc extends Bloc<PropertyInSectionImagesEvent, PropertyInSectionImagesState> {
+  final UploadPropertyInSectionImageUseCase uploadImage;
+  final UploadMultiplePropertyInSectionImagesUseCase uploadMultipleImages;
+  final GetPropertyInSectionImagesUseCase getImages;
+  final UpdatePropertyInSectionImageUseCase updateImage;
+  final DeletePropertyInSectionImageUseCase deleteImage;
+  final DeleteMultiplePropertyInSectionImagesUseCase deleteMultipleImages;
+  final ReorderPropertyInSectionImagesUseCase reorderImages;
+  final SetPrimaryPropertyInSectionImageUseCase setPrimaryImage;
+
+  List<SectionImage> _current = [];
+  Set<String> _selected = {};
+  String? _propertyInSectionId;
+
+  PropertyInSectionImagesBloc({
+    required this.uploadImage,
+    required this.uploadMultipleImages,
+    required this.getImages,
+    required this.updateImage,
+    required this.deleteImage,
+    required this.deleteMultipleImages,
+    required this.reorderImages,
+    required this.setPrimaryImage,
+  }) : super(const PropertyInSectionImagesInitial()) {
+    on<LoadPropertyInSectionImagesEvent>(_onLoad);
+    on<UploadPropertyInSectionImageEvent>(_onUpload);
+    on<UploadMultiplePropertyInSectionImagesEvent>(_onUploadMultiple);
+    on<UpdatePropertyInSectionImageEvent>(_onUpdate);
+    on<DeletePropertyInSectionImageEvent>(_onDelete);
+    on<DeleteMultiplePropertyInSectionImagesEvent>(_onDeleteMultiple);
+    on<ReorderPropertyInSectionImagesEvent>(_onReorder);
+    on<SetPrimaryPropertyInSectionImageEvent>(_onSetPrimary);
+    on<ToggleSelectPropertyInSectionImageEvent>(_onToggleSelect);
+    on<SelectAllPropertyInSectionImagesEvent>(_onSelectAll);
+    on<ClearPropertyInSectionSelectionEvent>(_onClearSelection);
+  }
+
+  Future<void> _onLoad(LoadPropertyInSectionImagesEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    _propertyInSectionId = e.propertyInSectionId;
+    emit(const PropertyInSectionImagesLoading());
+    final Either<Failure, List<SectionImage>> res = await getImages(GetPropertyInSectionImagesParams(propertyInSectionId: e.propertyInSectionId, page: e.page, limit: e.limit));
+    res.fold(
+      (f) => emit(PropertyInSectionImagesError(_msg(f))),
+      (list) { _current = list; emit(PropertyInSectionImagesLoaded(images: list, propertyInSectionId: e.propertyInSectionId)); },
+    );
+  }
+
+  Future<void> _onUpload(UploadPropertyInSectionImageEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(PropertyInSectionImageUploading(current: _current, fileName: e.filePath.split('/').last));
+    final res = await uploadImage(UploadPropertyInSectionImageParams(propertyInSectionId: e.propertyInSectionId, filePath: e.filePath, category: e.category, alt: e.alt, isPrimary: e.isPrimary, order: e.order, tags: e.tags, onSendProgress: (sent,total){ if(total>0) add(_ProgressEvent(e.propertyInSectionId, sent/total)); }));
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (img){ _current.add(img); emit(PropertyInSectionImageUploaded(uploaded: img, all: List.from(_current))); });
+  }
+
+  Future<void> _onUploadMultiple(UploadMultiplePropertyInSectionImagesEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(PropertyInSectionImageUploading(current: _current, total: e.filePaths.length, index: 0));
+    final res = await uploadMultipleImages(UploadMultiplePropertyInSectionImagesParams(propertyInSectionId: e.propertyInSectionId, filePaths: e.filePaths, category: e.category, tags: e.tags, onProgress: (path,sent,total){ if(total>0) add(_ProgressEvent(e.propertyInSectionId, sent/total)); }));
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (list){ _current.addAll(list); emit(MultiplePropertyInSectionImagesUploaded(uploaded: list, all: List.from(_current))); });
+  }
+
+  Future<void> _onUpdate(UpdatePropertyInSectionImageEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(PropertyInSectionImageUpdating(current: _current, imageId: e.imageId));
+    final res = await updateImage(UpdatePropertyInSectionImageParams(e.imageId, e.data));
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (_){ add(LoadPropertyInSectionImagesEvent(propertyInSectionId: _propertyInSectionId!)); });
+  }
+
+  Future<void> _onDelete(DeletePropertyInSectionImageEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(PropertyInSectionImageDeleting(current: _current, imageId: e.imageId));
+    final res = await deleteImage(_propertyInSectionId!, e.imageId, permanent: e.permanent);
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (ok){ if(ok){ _current.removeWhere((x)=>x.id==e.imageId); emit(PropertyInSectionImageDeleted(remaining: List.from(_current))); } });
+  }
+
+  Future<void> _onDeleteMultiple(DeleteMultiplePropertyInSectionImagesEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(const PropertyInSectionImagesLoading());
+    final res = await deleteMultipleImages(_propertyInSectionId!, e.imageIds);
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (ok){ if(ok){ _current.removeWhere((x)=> e.imageIds.contains(x.id)); _selected.clear(); emit(MultiplePropertyInSectionImagesDeleted(remaining: List.from(_current))); } });
+  }
+
+  Future<void> _onReorder(ReorderPropertyInSectionImagesEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(PropertyInSectionImagesReordering(current: _current));
+    final res = await reorderImages(ReorderPropertyInSectionImagesParams(_propertyInSectionId!, e.imageIds));
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (ok){ if(ok){ final map={for(final i in _current) i.id:i}; _current=e.imageIds.map((id)=>map[id]).whereType<SectionImage>().toList(); emit(PropertyInSectionImagesReordered(reordered: List.from(_current))); } });
+  }
+
+  Future<void> _onSetPrimary(SetPrimaryPropertyInSectionImageEvent e, Emitter<PropertyInSectionImagesState> emit) async {
+    emit(const PropertyInSectionImagesLoading());
+    final res = await setPrimaryImage(SetPrimaryPropertyInSectionImageParams(_propertyInSectionId!, e.imageId));
+    res.fold((f)=>emit(PropertyInSectionImagesError(_msg(f))), (_){ add(LoadPropertyInSectionImagesEvent(propertyInSectionId: _propertyInSectionId!)); });
+  }
+
+  void _onToggleSelect(ToggleSelectPropertyInSectionImageEvent e, Emitter<PropertyInSectionImagesState> emit){ if(_selected.contains(e.imageId)) _selected.remove(e.imageId); else _selected.add(e.imageId); emit(PropertyInSectionImagesLoaded(images:_current, propertyInSectionId:_propertyInSectionId, selected:Set.from(_selected), isSelectionMode:_selected.isNotEmpty)); }
+  void _onSelectAll(SelectAllPropertyInSectionImagesEvent e, Emitter<PropertyInSectionImagesState> emit){ _selected=_current.map((x)=>x.id).toSet(); emit(PropertyInSectionImagesLoaded(images:_current, propertyInSectionId:_propertyInSectionId, selected:Set.from(_selected), isSelectionMode:true)); }
+  void _onClearSelection(ClearPropertyInSectionSelectionEvent e, Emitter<PropertyInSectionImagesState> emit){ _selected.clear(); emit(PropertyInSectionImagesLoaded(images:_current, propertyInSectionId:_propertyInSectionId, selected:Set.from(_selected), isSelectionMode:false)); }
+
+  void _onProgress(_ProgressEvent e, Emitter<PropertyInSectionImagesState> emit){ emit(PropertyInSectionImageUploading(current: _current, progress: e.progress)); }
+  String _msg(Failure f){ if(f is ServerFailure) return f.message ?? 'Server Error'; if(f is NetworkFailure) return 'Network error'; return 'Unexpected error'; }
+}
+
+class _ProgressEvent extends PropertyInSectionImagesEvent{ final String propertyInSectionId; final double progress; _ProgressEvent(this.propertyInSectionId,this.progress); }
+

--- a/control_panel_app/lib/features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_event.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_event.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+abstract class PropertyInSectionImagesEvent extends Equatable { const PropertyInSectionImagesEvent(); @override List<Object?> get props=>[]; }
+
+class LoadPropertyInSectionImagesEvent extends PropertyInSectionImagesEvent { final String propertyInSectionId; final int? page; final int? limit; const LoadPropertyInSectionImagesEvent({required this.propertyInSectionId,this.page,this.limit}); @override List<Object?> get props=>[propertyInSectionId,page,limit]; }
+class UploadPropertyInSectionImageEvent extends PropertyInSectionImagesEvent { final String propertyInSectionId; final String filePath; final String? category; final String? alt; final bool isPrimary; final int? order; final List<String>? tags; const UploadPropertyInSectionImageEvent({required this.propertyInSectionId, required this.filePath, this.category, this.alt, this.isPrimary=false, this.order, this.tags}); }
+class UploadMultiplePropertyInSectionImagesEvent extends PropertyInSectionImagesEvent { final String propertyInSectionId; final List<String> filePaths; final String? category; final List<String>? tags; const UploadMultiplePropertyInSectionImagesEvent({required this.propertyInSectionId, required this.filePaths, this.category, this.tags}); }
+class UpdatePropertyInSectionImageEvent extends PropertyInSectionImagesEvent { final String imageId; final Map<String,dynamic> data; const UpdatePropertyInSectionImageEvent({required this.imageId, required this.data}); }
+class DeletePropertyInSectionImageEvent extends PropertyInSectionImagesEvent { final String imageId; final bool permanent; const DeletePropertyInSectionImageEvent({required this.imageId,this.permanent=false}); }
+class DeleteMultiplePropertyInSectionImagesEvent extends PropertyInSectionImagesEvent { final List<String> imageIds; const DeleteMultiplePropertyInSectionImagesEvent(this.imageIds); }
+class ReorderPropertyInSectionImagesEvent extends PropertyInSectionImagesEvent { final List<String> imageIds; const ReorderPropertyInSectionImagesEvent(this.imageIds); }
+class SetPrimaryPropertyInSectionImageEvent extends PropertyInSectionImagesEvent { final String imageId; const SetPrimaryPropertyInSectionImageEvent(this.imageId); }
+class ToggleSelectPropertyInSectionImageEvent extends PropertyInSectionImagesEvent { final String imageId; const ToggleSelectPropertyInSectionImageEvent(this.imageId); }
+class SelectAllPropertyInSectionImagesEvent extends PropertyInSectionImagesEvent { const SelectAllPropertyInSectionImagesEvent(); }
+class ClearPropertyInSectionSelectionEvent extends PropertyInSectionImagesEvent { const ClearPropertyInSectionSelectionEvent(); }
+

--- a/control_panel_app/lib/features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_state.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_state.dart
@@ -1,0 +1,18 @@
+import 'package:equatable/equatable.dart';
+import '../../../domain/entities/section_image.dart';
+
+abstract class PropertyInSectionImagesState extends Equatable { const PropertyInSectionImagesState(); @override List<Object?> get props=>[]; }
+class PropertyInSectionImagesInitial extends PropertyInSectionImagesState { const PropertyInSectionImagesInitial(); }
+class PropertyInSectionImagesLoading extends PropertyInSectionImagesState { const PropertyInSectionImagesLoading(); }
+class PropertyInSectionImagesError extends PropertyInSectionImagesState { final String message; const PropertyInSectionImagesError(this.message); @override List<Object?> get props=>[message]; }
+class PropertyInSectionImagesLoaded extends PropertyInSectionImagesState { final List<SectionImage> images; final String? propertyInSectionId; final Set<String>? selected; final bool isSelectionMode; const PropertyInSectionImagesLoaded({required this.images, this.propertyInSectionId, this.selected, this.isSelectionMode=false}); @override List<Object?> get props=>[images,propertyInSectionId,selected,isSelectionMode]; }
+class PropertyInSectionImageUploading extends PropertyInSectionImagesState { final List<SectionImage> current; final String? fileName; final double? progress; final int? total; final int? index; const PropertyInSectionImageUploading({required this.current,this.fileName,this.progress,this.total,this.index}); @override List<Object?> get props=>[current,fileName,progress,total,index]; }
+class PropertyInSectionImageUploaded extends PropertyInSectionImagesState { final SectionImage uploaded; final List<SectionImage> all; const PropertyInSectionImageUploaded({required this.uploaded,required this.all}); @override List<Object?> get props=>[uploaded,all]; }
+class MultiplePropertyInSectionImagesUploaded extends PropertyInSectionImagesState { final List<SectionImage> uploaded; final List<SectionImage> all; const MultiplePropertyInSectionImagesUploaded({required this.uploaded,required this.all}); }
+class PropertyInSectionImageUpdating extends PropertyInSectionImagesState { final List<SectionImage> current; final String imageId; const PropertyInSectionImageUpdating({required this.current, required this.imageId}); @override List<Object?> get props=>[current,imageId]; }
+class PropertyInSectionImageDeleting extends PropertyInSectionImagesState { final List<SectionImage> current; final String imageId; const PropertyInSectionImageDeleting({required this.current, required this.imageId}); @override List<Object?> get props=>[current,imageId]; }
+class PropertyInSectionImageDeleted extends PropertyInSectionImagesState { final List<SectionImage> remaining; const PropertyInSectionImageDeleted({required this.remaining}); }
+class MultiplePropertyInSectionImagesDeleted extends PropertyInSectionImagesState { final List<SectionImage> remaining; const MultiplePropertyInSectionImagesDeleted({required this.remaining}); }
+class PropertyInSectionImagesReordering extends PropertyInSectionImagesState { final List<SectionImage> current; const PropertyInSectionImagesReordering({required this.current}); }
+class PropertyInSectionImagesReordered extends PropertyInSectionImagesState { final List<SectionImage> reordered; const PropertyInSectionImagesReordered({required this.reordered}); }
+

--- a/control_panel_app/lib/features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_bloc.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_bloc.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failures.dart';
+import '../../../domain/entities/section_image.dart';
+import '../../../domain/usecases/unit_in_section_images/usecases.dart';
+import 'unit_in_section_images_event.dart';
+import 'unit_in_section_images_state.dart';
+
+class UnitInSectionImagesBloc extends Bloc<UnitInSectionImagesEvent, UnitInSectionImagesState> {
+  final UploadUnitInSectionImageUseCase uploadImage;
+  final UploadMultipleUnitInSectionImagesUseCase uploadMultipleImages;
+  final GetUnitInSectionImagesUseCase getImages;
+  final UpdateUnitInSectionImageUseCase updateImage;
+  final DeleteUnitInSectionImageUseCase deleteImage;
+  final DeleteMultipleUnitInSectionImagesUseCase deleteMultipleImages;
+  final ReorderUnitInSectionImagesUseCase reorderImages;
+  final SetPrimaryUnitInSectionImageUseCase setPrimaryImage;
+
+  List<SectionImage> _current = [];
+  Set<String> _selected = {};
+  String? _unitInSectionId;
+
+  UnitInSectionImagesBloc({
+    required this.uploadImage,
+    required this.uploadMultipleImages,
+    required this.getImages,
+    required this.updateImage,
+    required this.deleteImage,
+    required this.deleteMultipleImages,
+    required this.reorderImages,
+    required this.setPrimaryImage,
+  }) : super(const UnitInSectionImagesInitial()) {
+    on<LoadUnitInSectionImagesEvent>(_onLoad);
+    on<UploadUnitInSectionImageEvent>(_onUpload);
+    on<UploadMultipleUnitInSectionImagesEvent>(_onUploadMultiple);
+    on<UpdateUnitInSectionImageEvent>(_onUpdate);
+    on<DeleteUnitInSectionImageEvent>(_onDelete);
+    on<DeleteMultipleUnitInSectionImagesEvent>(_onDeleteMultiple);
+    on<ReorderUnitInSectionImagesEvent>(_onReorder);
+    on<SetPrimaryUnitInSectionImageEvent>(_onSetPrimary);
+    on<ToggleSelectUnitInSectionImageEvent>(_onToggleSelect);
+    on<SelectAllUnitInSectionImagesEvent>(_onSelectAll);
+    on<ClearUnitInSectionSelectionEvent>(_onClearSelection);
+  }
+
+  Future<void> _onLoad(LoadUnitInSectionImagesEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    _unitInSectionId = e.unitInSectionId;
+    emit(const UnitInSectionImagesLoading());
+    final Either<Failure, List<SectionImage>> res = await getImages(GetUnitInSectionImagesParams(unitInSectionId: e.unitInSectionId, page: e.page, limit: e.limit));
+    res.fold(
+      (f) => emit(UnitInSectionImagesError(_msg(f))),
+      (list) { _current = list; emit(UnitInSectionImagesLoaded(images: list, unitInSectionId: e.unitInSectionId)); },
+    );
+  }
+
+  Future<void> _onUpload(UploadUnitInSectionImageEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(UnitInSectionImageUploading(current: _current, fileName: e.filePath.split('/').last));
+    final res = await uploadImage(UploadUnitInSectionImageParams(unitInSectionId: e.unitInSectionId, filePath: e.filePath, category: e.category, alt: e.alt, isPrimary: e.isPrimary, order: e.order, tags: e.tags, onSendProgress: (sent,total){ if(total>0) add(_ProgressEvent(e.unitInSectionId, sent/total)); }));
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (img){ _current.add(img); emit(UnitInSectionImageUploaded(uploaded: img, all: List.from(_current))); });
+  }
+
+  Future<void> _onUploadMultiple(UploadMultipleUnitInSectionImagesEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(UnitInSectionImageUploading(current: _current, total: e.filePaths.length, index: 0));
+    final res = await uploadMultipleImages(UploadMultipleUnitInSectionImagesParams(unitInSectionId: e.unitInSectionId, filePaths: e.filePaths, category: e.category, tags: e.tags, onProgress: (path,sent,total){ if(total>0) add(_ProgressEvent(e.unitInSectionId, sent/total)); }));
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (list){ _current.addAll(list); emit(MultipleUnitInSectionImagesUploaded(uploaded: list, all: List.from(_current))); });
+  }
+
+  Future<void> _onUpdate(UpdateUnitInSectionImageEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(UnitInSectionImageUpdating(current: _current, imageId: e.imageId));
+    final res = await updateImage(UpdateUnitInSectionImageParams(e.imageId, e.data));
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (_){ add(LoadUnitInSectionImagesEvent(unitInSectionId: _unitInSectionId!)); });
+  }
+
+  Future<void> _onDelete(DeleteUnitInSectionImageEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(UnitInSectionImageDeleting(current: _current, imageId: e.imageId));
+    final res = await deleteImage(_unitInSectionId!, e.imageId, permanent: e.permanent);
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (ok){ if(ok){ _current.removeWhere((x)=>x.id==e.imageId); emit(UnitInSectionImageDeleted(remaining: List.from(_current))); } });
+  }
+
+  Future<void> _onDeleteMultiple(DeleteMultipleUnitInSectionImagesEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(const UnitInSectionImagesLoading());
+    final res = await deleteMultipleImages(_unitInSectionId!, e.imageIds);
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (ok){ if(ok){ _current.removeWhere((x)=> e.imageIds.contains(x.id)); _selected.clear(); emit(MultipleUnitInSectionImagesDeleted(remaining: List.from(_current))); } });
+  }
+
+  Future<void> _onReorder(ReorderUnitInSectionImagesEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(UnitInSectionImagesReordering(current: _current));
+    final res = await reorderImages(ReorderUnitInSectionImagesParams(_unitInSectionId!, e.imageIds));
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (ok){ if(ok){ final map={for(final i in _current) i.id:i}; _current=e.imageIds.map((id)=>map[id]).whereType<SectionImage>().toList(); emit(UnitInSectionImagesReordered(reordered: List.from(_current))); } });
+  }
+
+  Future<void> _onSetPrimary(SetPrimaryUnitInSectionImageEvent e, Emitter<UnitInSectionImagesState> emit) async {
+    emit(const UnitInSectionImagesLoading());
+    final res = await setPrimaryImage(SetPrimaryUnitInSectionImageParams(_unitInSectionId!, e.imageId));
+    res.fold((f)=>emit(UnitInSectionImagesError(_msg(f))), (_){ add(LoadUnitInSectionImagesEvent(unitInSectionId: _unitInSectionId!)); });
+  }
+
+  void _onToggleSelect(ToggleSelectUnitInSectionImageEvent e, Emitter<UnitInSectionImagesState> emit){ if(_selected.contains(e.imageId)) _selected.remove(e.imageId); else _selected.add(e.imageId); emit(UnitInSectionImagesLoaded(images:_current, unitInSectionId:_unitInSectionId, selected:Set.from(_selected), isSelectionMode:_selected.isNotEmpty)); }
+  void _onSelectAll(SelectAllUnitInSectionImagesEvent e, Emitter<UnitInSectionImagesState> emit){ _selected=_current.map((x)=>x.id).toSet(); emit(UnitInSectionImagesLoaded(images:_current, unitInSectionId:_unitInSectionId, selected:Set.from(_selected), isSelectionMode:true)); }
+  void _onClearSelection(ClearUnitInSectionSelectionEvent e, Emitter<UnitInSectionImagesState> emit){ _selected.clear(); emit(UnitInSectionImagesLoaded(images:_current, unitInSectionId:_unitInSectionId, selected:Set.from(_selected), isSelectionMode:false)); }
+
+  void _onProgress(_ProgressEvent e, Emitter<UnitInSectionImagesState> emit){ emit(UnitInSectionImageUploading(current: _current, progress: e.progress)); }
+  String _msg(Failure f){ if(f is ServerFailure) return f.message ?? 'Server Error'; if(f is NetworkFailure) return 'Network error'; return 'Unexpected error'; }
+}
+
+class _ProgressEvent extends UnitInSectionImagesEvent{ final String unitInSectionId; final double progress; _ProgressEvent(this.unitInSectionId,this.progress); }
+

--- a/control_panel_app/lib/features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_event.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_event.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+abstract class UnitInSectionImagesEvent extends Equatable { const UnitInSectionImagesEvent(); @override List<Object?> get props=>[]; }
+
+class LoadUnitInSectionImagesEvent extends UnitInSectionImagesEvent { final String unitInSectionId; final int? page; final int? limit; const LoadUnitInSectionImagesEvent({required this.unitInSectionId,this.page,this.limit}); @override List<Object?> get props=>[unitInSectionId,page,limit]; }
+class UploadUnitInSectionImageEvent extends UnitInSectionImagesEvent { final String unitInSectionId; final String filePath; final String? category; final String? alt; final bool isPrimary; final int? order; final List<String>? tags; const UploadUnitInSectionImageEvent({required this.unitInSectionId, required this.filePath, this.category, this.alt, this.isPrimary=false, this.order, this.tags}); }
+class UploadMultipleUnitInSectionImagesEvent extends UnitInSectionImagesEvent { final String unitInSectionId; final List<String> filePaths; final String? category; final List<String>? tags; const UploadMultipleUnitInSectionImagesEvent({required this.unitInSectionId, required this.filePaths, this.category, this.tags}); }
+class UpdateUnitInSectionImageEvent extends UnitInSectionImagesEvent { final String imageId; final Map<String,dynamic> data; const UpdateUnitInSectionImageEvent({required this.imageId, required this.data}); }
+class DeleteUnitInSectionImageEvent extends UnitInSectionImagesEvent { final String imageId; final bool permanent; const DeleteUnitInSectionImageEvent({required this.imageId,this.permanent=false}); }
+class DeleteMultipleUnitInSectionImagesEvent extends UnitInSectionImagesEvent { final List<String> imageIds; const DeleteMultipleUnitInSectionImagesEvent(this.imageIds); }
+class ReorderUnitInSectionImagesEvent extends UnitInSectionImagesEvent { final List<String> imageIds; const ReorderUnitInSectionImagesEvent(this.imageIds); }
+class SetPrimaryUnitInSectionImageEvent extends UnitInSectionImagesEvent { final String imageId; const SetPrimaryUnitInSectionImageEvent(this.imageId); }
+class ToggleSelectUnitInSectionImageEvent extends UnitInSectionImagesEvent { final String imageId; const ToggleSelectUnitInSectionImageEvent(this.imageId); }
+class SelectAllUnitInSectionImagesEvent extends UnitInSectionImagesEvent { const SelectAllUnitInSectionImagesEvent(); }
+class ClearUnitInSectionSelectionEvent extends UnitInSectionImagesEvent { const ClearUnitInSectionSelectionEvent(); }
+

--- a/control_panel_app/lib/features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_state.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_state.dart
@@ -1,0 +1,18 @@
+import 'package:equatable/equatable.dart';
+import '../../../domain/entities/section_image.dart';
+
+abstract class UnitInSectionImagesState extends Equatable { const UnitInSectionImagesState(); @override List<Object?> get props=>[]; }
+class UnitInSectionImagesInitial extends UnitInSectionImagesState { const UnitInSectionImagesInitial(); }
+class UnitInSectionImagesLoading extends UnitInSectionImagesState { const UnitInSectionImagesLoading(); }
+class UnitInSectionImagesError extends UnitInSectionImagesState { final String message; const UnitInSectionImagesError(this.message); @override List<Object?> get props=>[message]; }
+class UnitInSectionImagesLoaded extends UnitInSectionImagesState { final List<SectionImage> images; final String? unitInSectionId; final Set<String>? selected; final bool isSelectionMode; const UnitInSectionImagesLoaded({required this.images, this.unitInSectionId, this.selected, this.isSelectionMode=false}); @override List<Object?> get props=>[images,unitInSectionId,selected,isSelectionMode]; }
+class UnitInSectionImageUploading extends UnitInSectionImagesState { final List<SectionImage> current; final String? fileName; final double? progress; final int? total; final int? index; const UnitInSectionImageUploading({required this.current,this.fileName,this.progress,this.total,this.index}); @override List<Object?> get props=>[current,fileName,progress,total,index]; }
+class UnitInSectionImageUploaded extends UnitInSectionImagesState { final SectionImage uploaded; final List<SectionImage> all; const UnitInSectionImageUploaded({required this.uploaded,required this.all}); @override List<Object?> get props=>[uploaded,all]; }
+class MultipleUnitInSectionImagesUploaded extends UnitInSectionImagesState { final List<SectionImage> uploaded; final List<SectionImage> all; const MultipleUnitInSectionImagesUploaded({required this.uploaded,required this.all}); }
+class UnitInSectionImageUpdating extends UnitInSectionImagesState { final List<SectionImage> current; final String imageId; const UnitInSectionImageUpdating({required this.current, required this.imageId}); @override List<Object?> get props=>[current,imageId]; }
+class UnitInSectionImageDeleting extends UnitInSectionImagesState { final List<SectionImage> current; final String imageId; const UnitInSectionImageDeleting({required this.current, required this.imageId}); @override List<Object?> get props=>[current,imageId]; }
+class UnitInSectionImageDeleted extends UnitInSectionImagesState { final List<SectionImage> remaining; const UnitInSectionImageDeleted({required this.remaining}); }
+class MultipleUnitInSectionImagesDeleted extends UnitInSectionImagesState { final List<SectionImage> remaining; const MultipleUnitInSectionImagesDeleted({required this.remaining}); }
+class UnitInSectionImagesReordering extends UnitInSectionImagesState { final List<SectionImage> current; const UnitInSectionImagesReordering({required this.current}); }
+class UnitInSectionImagesReordered extends UnitInSectionImagesState { final List<SectionImage> reordered; const UnitInSectionImagesReordered({required this.reordered}); }
+

--- a/control_panel_app/lib/injection_container.dart
+++ b/control_panel_app/lib/injection_container.dart
@@ -44,6 +44,24 @@ import 'package:bookn_cp_app/services/section_service.dart';
 import 'features/admin_sections/data/datasources/section_images_remote_datasource.dart';
 import 'features/admin_sections/data/datasources/property_in_section_images_remote_datasource.dart';
 import 'features/admin_sections/data/datasources/unit_in_section_images_remote_datasource.dart';
+import 'features/admin_sections/domain/repositories/section_images_repository.dart';
+import 'features/admin_sections/data/repositories/section_images_repository_impl.dart';
+import 'features/admin_sections/domain/usecases/section_images/usecases.dart';
+import 'features/admin_sections/presentation/bloc/section_images/section_images_bloc.dart';
+import 'features/admin_sections/presentation/bloc/section_images/section_images_event.dart';
+import 'features/admin_sections/presentation/bloc/section_images/section_images_state.dart';
+import 'features/admin_sections/domain/repositories/property_in_section_images_repository.dart';
+import 'features/admin_sections/data/repositories/property_in_section_images_repository_impl.dart';
+import 'features/admin_sections/domain/usecases/property_in_section_images/usecases.dart' as pis_uc;
+import 'features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_bloc.dart';
+import 'features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_event.dart';
+import 'features/admin_sections/presentation/bloc/property_in_section_images/property_in_section_images_state.dart';
+import 'features/admin_sections/domain/repositories/unit_in_section_images_repository.dart';
+import 'features/admin_sections/data/repositories/unit_in_section_images_repository_impl.dart';
+import 'features/admin_sections/domain/usecases/unit_in_section_images/usecases.dart' as uis_uc;
+import 'features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_bloc.dart';
+import 'features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_event.dart';
+import 'features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_state.dart';
 
 import 'package:get_it/get_it.dart';
 import 'package:dio/dio.dart';
@@ -1836,6 +1854,54 @@ void _initAdminSections() {
   sl.registerLazySingleton(() => ReorderSectionImagesUseCase(sl()));
   sl.registerLazySingleton(() => SetPrimarySectionImageUseCase(sl()));
   sl.registerFactory(() => SectionImagesBloc(
+        uploadImage: sl(),
+        uploadMultipleImages: sl(),
+        getImages: sl(),
+        updateImage: sl(),
+        deleteImage: sl(),
+        deleteMultipleImages: sl(),
+        reorderImages: sl(),
+        setPrimaryImage: sl(),
+      ));
+
+  // PropertyInSection Images Repository + UseCases + Bloc
+  sl.registerLazySingleton<PropertyInSectionImagesRepository>(() => PropertyInSectionImagesRepositoryImpl(
+        remoteDataSource: sl(),
+        networkInfo: sl(),
+      ));
+  sl.registerLazySingleton(() => pis_uc.UploadPropertyInSectionImageUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.UploadMultiplePropertyInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.GetPropertyInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.UpdatePropertyInSectionImageUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.DeletePropertyInSectionImageUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.DeleteMultiplePropertyInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.ReorderPropertyInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => pis_uc.SetPrimaryPropertyInSectionImageUseCase(sl()));
+  sl.registerFactory(() => PropertyInSectionImagesBloc(
+        uploadImage: sl(),
+        uploadMultipleImages: sl(),
+        getImages: sl(),
+        updateImage: sl(),
+        deleteImage: sl(),
+        deleteMultipleImages: sl(),
+        reorderImages: sl(),
+        setPrimaryImage: sl(),
+      ));
+
+  // UnitInSection Images Repository + UseCases + Bloc
+  sl.registerLazySingleton<UnitInSectionImagesRepository>(() => UnitInSectionImagesRepositoryImpl(
+        remoteDataSource: sl(),
+        networkInfo: sl(),
+      ));
+  sl.registerLazySingleton(() => uis_uc.UploadUnitInSectionImageUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.UploadMultipleUnitInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.GetUnitInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.UpdateUnitInSectionImageUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.DeleteUnitInSectionImageUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.DeleteMultipleUnitInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.ReorderUnitInSectionImagesUseCase(sl()));
+  sl.registerLazySingleton(() => uis_uc.SetPrimaryUnitInSectionImageUseCase(sl()));
+  sl.registerFactory(() => UnitInSectionImagesBloc(
         uploadImage: sl(),
         uploadMultipleImages: sl(),
         getImages: sl(),


### PR DESCRIPTION
Add UseCase, Repository, and BLoC for property-in-section and unit-in-section images to complete the `admin_sections` feature, mirroring existing section image architecture and ensuring backend compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-3445907b-ac37-497d-9a3e-68078ebce0a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3445907b-ac37-497d-9a3e-68078ebce0a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

