### PR TITLE
Adapt image handling for admin sections

### DIFF
--- a/control_panel_app/lib/features/admin_sections/data/repositories/property_in_section_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_sections/data/repositories/property_in_section_images_repository_impl.dart
@@ -67,6 +67,22 @@ class PropertyInSectionImagesRepositoryImpl implements PropertyInSectionImagesRe
   }
 
   @override
+  Future<Either<Failure, List<SectionImage>>> getImagesByTempKey(String tempKey, {int? page, int? limit}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final List<SectionImageModel> result = await remoteDataSource.getImagesByTempKey(tempKey, page: page, limit: limit);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
   Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data) async {
     if (await networkInfo.isConnected) {
       try {
@@ -86,7 +102,23 @@ class PropertyInSectionImagesRepositoryImpl implements PropertyInSectionImagesRe
   Future<Either<Failure, bool>> deleteImage(String propertyInSectionId, String imageId, {bool permanent = false}) async {
     if (await networkInfo.isConnected) {
       try {
-        final bool result = await remoteDataSource.deleteImage(propertyInSectionId, imageId, permanent: permanent);
+        final bool result = await remoteDataSource.deleteImageById(imageId, permanent: permanent);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteImageById(String imageId, {bool permanent = false}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.deleteImageById(imageId, permanent: permanent);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));
@@ -115,10 +147,42 @@ class PropertyInSectionImagesRepositoryImpl implements PropertyInSectionImagesRe
   }
 
   @override
+  Future<Either<Failure, bool>> reorderImagesByTempKey(String tempKey, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.reorderImagesByTempKey(tempKey, imageIds);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
   Future<Either<Failure, bool>> setAsPrimaryImage(String propertyInSectionId, String imageId) async {
     if (await networkInfo.isConnected) {
       try {
         final bool result = await remoteDataSource.setAsPrimaryImage(propertyInSectionId, imageId);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> setAsPrimaryImageByTempKey(String imageId, String tempKey) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.setAsPrimaryImageByTempKey(imageId, tempKey);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));

--- a/control_panel_app/lib/features/admin_sections/data/repositories/section_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_sections/data/repositories/section_images_repository_impl.dart
@@ -67,6 +67,22 @@ class SectionImagesRepositoryImpl implements SectionImagesRepository {
   }
 
   @override
+  Future<Either<Failure, List<SectionImage>>> getImagesByTempKey(String tempKey, {int? page, int? limit}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final List<SectionImageModel> result = await remoteDataSource.getImagesByTempKey(tempKey, page: page, limit: limit);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
   Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data) async {
     if (await networkInfo.isConnected) {
       try {
@@ -86,7 +102,23 @@ class SectionImagesRepositoryImpl implements SectionImagesRepository {
   Future<Either<Failure, bool>> deleteImage(String sectionId, String imageId, {bool permanent = false}) async {
     if (await networkInfo.isConnected) {
       try {
-        final bool result = await remoteDataSource.deleteImage(sectionId, imageId, permanent: permanent);
+        final bool result = await remoteDataSource.deleteImage(imageId, permanent: permanent);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteImageById(String imageId, {bool permanent = false}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.deleteImage(imageId, permanent: permanent);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));
@@ -102,7 +134,23 @@ class SectionImagesRepositoryImpl implements SectionImagesRepository {
   Future<Either<Failure, bool>> reorderImages(String sectionId, List<String> imageIds) async {
     if (await networkInfo.isConnected) {
       try {
-        final bool result = await remoteDataSource.reorderImages(sectionId, imageIds);
+        final bool result = await remoteDataSource.reorderImages(imageIds, tempKey: null);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> reorderImagesByTempKey(String tempKey, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.reorderImages(imageIds, tempKey: tempKey);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));
@@ -118,7 +166,23 @@ class SectionImagesRepositoryImpl implements SectionImagesRepository {
   Future<Either<Failure, bool>> setAsPrimaryImage(String sectionId, String imageId) async {
     if (await networkInfo.isConnected) {
       try {
-        final bool result = await remoteDataSource.setAsPrimaryImage(sectionId, imageId);
+        final bool result = await remoteDataSource.setAsPrimaryImage(imageId, tempKey: null);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> setAsPrimaryImageByTempKey(String imageId, String tempKey) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.setAsPrimaryImage(imageId, tempKey: tempKey);
         return Right(result);
       } on ServerException catch (e) {
         return Left(ServerFailure(e.message));

--- a/control_panel_app/lib/features/admin_sections/data/repositories/unit_in_section_images_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_sections/data/repositories/unit_in_section_images_repository_impl.dart
@@ -67,6 +67,249 @@ class UnitInSectionImagesRepositoryImpl implements UnitInSectionImagesRepository
   }
 
   @override
+  Future<Either<Failure, List<SectionImage>>> getImagesByTempKey(String tempKey, {int? page, int? limit}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final List<SectionImageModel> result = await remoteDataSource.getImagesByTempKey(tempKey, page: page, limit: limit);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.updateImage(imageId, data);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteImage(String unitInSectionId, String imageId, {bool permanent = false}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.deleteImageById(imageId, permanent: permanent);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteImageById(String imageId, {bool permanent = false}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.deleteImageById(imageId, permanent: permanent);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> reorderImages(String unitInSectionId, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.reorderImages(unitInSectionId, imageIds);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> reorderImagesByTempKey(String tempKey, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.reorderImagesByTempKey(tempKey, imageIds);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> setAsPrimaryImage(String unitInSectionId, String imageId) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.setAsPrimaryImage(unitInSectionId, imageId);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> setAsPrimaryImageByTempKey(String imageId, String tempKey) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final bool result = await remoteDataSource.setAsPrimaryImageByTempKey(imageId, tempKey);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
+    required String unitInSectionId,
+    required List<String> filePaths,
+    String? category,
+    List<String>? tags,
+    void Function(String filePath, int sent, int total)? onProgress,
+  }) async {
+    if (await networkInfo.isConnected) {
+      final uploaded = <SectionImage>[];
+      for (final path in filePaths) {
+        final res = await uploadImage(
+          unitInSectionId: unitInSectionId,
+          filePath: path,
+          category: category,
+          tags: tags,
+          onSendProgress: (sent, total) => onProgress?.call(path, sent, total),
+        );
+        res.fold((_) {}, (img) => uploaded.add(img));
+      }
+      return Right(uploaded);
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> deleteMultipleImages(String unitInSectionId, List<String> imageIds) async {
+    if (await networkInfo.isConnected) {
+      try {
+        var ok = true;
+        for (final id in imageIds) {
+          final res = await deleteImage(unitInSectionId, id);
+          res.fold((_) => ok = false, (_) {});
+        }
+        return Right(ok);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+}
+
+import 'package:dartz/dartz.dart';
+import 'package:dio/dio.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/section_image.dart';
+import '../../domain/repositories/unit_in_section_images_repository.dart';
+import '../datasources/unit_in_section_images_remote_datasource.dart';
+import '../models/section_image_model.dart';
+
+class UnitInSectionImagesRepositoryImpl implements UnitInSectionImagesRepository {
+  final UnitInSectionImagesRemoteDataSource remoteDataSource;
+  final NetworkInfo networkInfo;
+
+  UnitInSectionImagesRepositoryImpl({required this.remoteDataSource, required this.networkInfo});
+
+  @override
+  Future<Either<Failure, SectionImage>> uploadImage({
+    required String unitInSectionId,
+    required String filePath,
+    String? category,
+    String? alt,
+    bool isPrimary = false,
+    int? order,
+    List<String>? tags,
+    ProgressCallback? onSendProgress,
+    String? tempKey,
+  }) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final SectionImageModel result = await remoteDataSource.uploadImage(
+          unitInSectionId: unitInSectionId,
+          filePath: filePath,
+          category: category,
+          alt: alt,
+          isPrimary: isPrimary,
+          order: order,
+          tags: tags,
+          tempKey: tempKey,
+          onSendProgress: onSendProgress,
+        );
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
+  Future<Either<Failure, List<SectionImage>>> getImages(String unitInSectionId, {int? page, int? limit}) async {
+    if (await networkInfo.isConnected) {
+      try {
+        final List<SectionImageModel> result = await remoteDataSource.getImages(unitInSectionId, page: page, limit: limit);
+        return Right(result);
+      } on ServerException catch (e) {
+        return Left(ServerFailure(e.message));
+      } catch (e) {
+        return Left(ServerFailure('An unexpected error occurred: ${e.toString()}'));
+      }
+    } else {
+      return const Left(NetworkFailure());
+    }
+  }
+
+  @override
   Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data) async {
     if (await networkInfo.isConnected) {
       try {

--- a/control_panel_app/lib/features/admin_sections/domain/repositories/property_in_section_images_repository.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/repositories/property_in_section_images_repository.dart
@@ -17,14 +17,18 @@ abstract class PropertyInSectionImagesRepository {
   });
 
   Future<Either<Failure, List<SectionImage>>> getImages(String propertyInSectionId, {int? page, int? limit});
+  Future<Either<Failure, List<SectionImage>>> getImagesByTempKey(String tempKey, {int? page, int? limit});
 
   Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data);
 
   Future<Either<Failure, bool>> deleteImage(String propertyInSectionId, String imageId, {bool permanent});
+  Future<Either<Failure, bool>> deleteImageById(String imageId, {bool permanent});
 
   Future<Either<Failure, bool>> reorderImages(String propertyInSectionId, List<String> imageIds);
+  Future<Either<Failure, bool>> reorderImagesByTempKey(String tempKey, List<String> imageIds);
 
   Future<Either<Failure, bool>> setAsPrimaryImage(String propertyInSectionId, String imageId);
+  Future<Either<Failure, bool>> setAsPrimaryImageByTempKey(String imageId, String tempKey);
 
   Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
     required String propertyInSectionId,

--- a/control_panel_app/lib/features/admin_sections/domain/repositories/section_images_repository.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/repositories/section_images_repository.dart
@@ -17,14 +17,18 @@ abstract class SectionImagesRepository {
   });
 
   Future<Either<Failure, List<SectionImage>>> getImages(String sectionId, {int? page, int? limit});
+  Future<Either<Failure, List<SectionImage>>> getImagesByTempKey(String tempKey, {int? page, int? limit});
 
   Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data);
 
   Future<Either<Failure, bool>> deleteImage(String sectionId, String imageId, {bool permanent});
+  Future<Either<Failure, bool>> deleteImageById(String imageId, {bool permanent});
 
   Future<Either<Failure, bool>> reorderImages(String sectionId, List<String> imageIds);
+  Future<Either<Failure, bool>> reorderImagesByTempKey(String tempKey, List<String> imageIds);
 
   Future<Either<Failure, bool>> setAsPrimaryImage(String sectionId, String imageId);
+  Future<Either<Failure, bool>> setAsPrimaryImageByTempKey(String imageId, String tempKey);
 
   Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
     required String sectionId,

--- a/control_panel_app/lib/features/admin_sections/domain/repositories/unit_in_section_images_repository.dart
+++ b/control_panel_app/lib/features/admin_sections/domain/repositories/unit_in_section_images_repository.dart
@@ -17,14 +17,18 @@ abstract class UnitInSectionImagesRepository {
   });
 
   Future<Either<Failure, List<SectionImage>>> getImages(String unitInSectionId, {int? page, int? limit});
+  Future<Either<Failure, List<SectionImage>>> getImagesByTempKey(String tempKey, {int? page, int? limit});
 
   Future<Either<Failure, bool>> updateImage(String imageId, Map<String, dynamic> data);
 
   Future<Either<Failure, bool>> deleteImage(String unitInSectionId, String imageId, {bool permanent});
+  Future<Either<Failure, bool>> deleteImageById(String imageId, {bool permanent});
 
   Future<Either<Failure, bool>> reorderImages(String unitInSectionId, List<String> imageIds);
+  Future<Either<Failure, bool>> reorderImagesByTempKey(String tempKey, List<String> imageIds);
 
   Future<Either<Failure, bool>> setAsPrimaryImage(String unitInSectionId, String imageId);
+  Future<Either<Failure, bool>> setAsPrimaryImageByTempKey(String imageId, String tempKey);
 
   Future<Either<Failure, List<SectionImage>>> uploadMultipleImages({
     required String unitInSectionId,


### PR DESCRIPTION
Add `tempKey` support for image management in `admin_sections` to allow image handling before the main entity is created, mirroring `admin_properties` behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-bbe59ae8-a0aa-4326-b4c2-24d728543c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bbe59ae8-a0aa-4326-b4c2-24d728543c96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

