### PR TITLE
Verify admin sections setup

### DIFF
--- a/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
+++ b/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
@@ -1568,6 +1568,13 @@ class _AdminHubPageState extends State<AdminHubPage>
           onTap: () => context.push('/admin/currencies'),
         ),
         _AdminFeature(
+          title: 'الأقسام',
+          description: 'إدارة أقسام الواجهة والمحتوى',
+          icon: Icons.view_quilt_rounded,
+          gradient: [AppTheme.primaryCyan, AppTheme.primaryPurple],
+          onTap: () => context.push('/admin/sections'),
+        ),
+        _AdminFeature(
           title: 'المدفوعات',
           description: 'إدارة المعاملات المالية والاستردادات',
           icon: Icons.account_balance_wallet_rounded,

--- a/control_panel_app/lib/injection_container.dart
+++ b/control_panel_app/lib/injection_container.dart
@@ -64,6 +64,9 @@ import 'features/admin_sections/domain/usecases/unit_in_section_images/usecases.
 import 'features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_bloc.dart';
 import 'features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_event.dart';
 import 'features/admin_sections/presentation/bloc/unit_in_section_images/unit_in_section_images_state.dart';
+import 'features/admin_sections/presentation/bloc/sections_list/sections_list_bloc.dart';
+import 'features/admin_sections/presentation/bloc/section_form/section_form_bloc.dart';
+import 'features/admin_sections/presentation/bloc/section_items/section_items_bloc.dart';
 
 import 'package:get_it/get_it.dart';
 import 'package:dio/dio.dart';
@@ -1927,6 +1930,23 @@ void _initAdminSections() {
         deleteMultipleImages: sl(),
         reorderImages: sl(),
         setPrimaryImage: sl(),
+      ));
+
+  // Admin Sections BLoCs (list, form, items management)
+  sl.registerFactory(() => SectionsListBloc(
+        getAllSections: sl(),
+        deleteSection: sl(),
+        toggleStatus: sl(),
+      ));
+  sl.registerFactory(() => SectionFormBloc(
+        createSection: sl(),
+        updateSection: sl(),
+      ));
+  sl.registerFactory(() => SectionItemsBloc(
+        getItems: sl(),
+        addItems: sl(),
+        removeItems: sl(),
+        reorderItems: sl(),
       ));
 }
 

--- a/control_panel_app/lib/routes/app_router.dart
+++ b/control_panel_app/lib/routes/app_router.dart
@@ -163,6 +163,22 @@ import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_d
 import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_analytics/payment_analytics_bloc.dart'
     as pay_an_bloc;
 import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_refund/payment_refund_bloc.dart';
+// Admin Sections pages & blocs
+import 'package:bookn_cp_app/features/admin_sections/presentation/pages/sections_list_page.dart'
+    as sec_pages;
+import 'package:bookn_cp_app/features/admin_sections/presentation/pages/create_section_page.dart'
+    as sec_pages;
+import 'package:bookn_cp_app/features/admin_sections/presentation/pages/edit_section_page.dart'
+    as sec_pages;
+import 'package:bookn_cp_app/features/admin_sections/presentation/pages/section_items_management_page.dart'
+    as sec_pages;
+import 'package:bookn_cp_app/features/admin_sections/presentation/bloc/sections_list/sections_list_bloc.dart'
+    as sec_list_bloc;
+import 'package:bookn_cp_app/features/admin_sections/presentation/bloc/section_form/section_form_bloc.dart'
+    as sec_form_bloc;
+import 'package:bookn_cp_app/features/admin_sections/presentation/bloc/section_items/section_items_bloc.dart'
+    as sec_items_bloc;
+import 'package:bookn_cp_app/core/enums/section_target.dart' as sec_enums;
 
 class AppRouter {
   static GoRouter build(BuildContext context) {
@@ -608,6 +624,58 @@ class AppRouter {
                 ),
               ],
               child: const ap_pages.PropertiesListPage(),
+            );
+          },
+        ),
+
+        // Admin Sections - list
+        GoRoute(
+          path: '/admin/sections',
+          builder: (context, state) {
+            return BlocProvider<sec_list_bloc.SectionsListBloc>(
+              create: (_) => di.sl<sec_list_bloc.SectionsListBloc>(),
+              child: const sec_pages.SectionsListPage(),
+            );
+          },
+        ),
+
+        // Admin Sections - create
+        GoRoute(
+          path: '/admin/sections/create',
+          builder: (context, state) {
+            return BlocProvider<sec_form_bloc.SectionFormBloc>(
+              create: (_) => di.sl<sec_form_bloc.SectionFormBloc>()
+                ..add(const sec_form_bloc.InitializeSectionFormEvent()),
+              child: const sec_pages.CreateSectionPage(),
+            );
+          },
+        ),
+
+        // Admin Sections - edit
+        GoRoute(
+          path: '/admin/sections/:sectionId/edit',
+          builder: (context, state) {
+            final sectionId = state.pathParameters['sectionId']!;
+            return BlocProvider<sec_form_bloc.SectionFormBloc>(
+              create: (_) => di.sl<sec_form_bloc.SectionFormBloc>()
+                ..add(sec_form_bloc.InitializeSectionFormEvent(sectionId: sectionId)),
+              child: sec_pages.EditSectionPage(sectionId: sectionId),
+            );
+          },
+        ),
+
+        // Admin Sections - manage items
+        GoRoute(
+          path: '/admin/sections/:sectionId/items',
+          builder: (context, state) {
+            final sectionId = state.pathParameters['sectionId']!;
+            final target = state.extra as sec_enums.SectionTarget? ?? sec_enums.SectionTarget.properties;
+            return BlocProvider<sec_items_bloc.SectionItemsBloc>(
+              create: (_) => di.sl<sec_items_bloc.SectionItemsBloc>(),
+              child: sec_pages.SectionItemsManagementPage(
+                sectionId: sectionId,
+                target: target,
+              ),
             );
           },
         ),


### PR DESCRIPTION
Integrate the `admin_sections` feature by adding its blocs to DI, defining its routes, and creating an entry point in the admin hub.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd4088d1-bf29-4bb0-9187-db7059a0a903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd4088d1-bf29-4bb0-9187-db7059a0a903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

