### PR TITLE
Implement section items management page access

### DIFF
--- a/control_panel_app/lib/features/admin_sections/presentation/pages/sections_list_page.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/pages/sections_list_page.dart
@@ -561,6 +561,7 @@ class _SectionsListPageState extends State<SectionsListPage>
           onEdit: _navigateToEdit,
           onDelete: _confirmDelete,
           onToggleStatus: _toggleStatus,
+          onManageItems: _navigateToManageItems,
         ),
       ),
     );

--- a/control_panel_app/lib/features/admin_sections/presentation/widgets/futuristic_sections_table.dart
+++ b/control_panel_app/lib/features/admin_sections/presentation/widgets/futuristic_sections_table.dart
@@ -12,6 +12,7 @@ class FuturisticSectionsTable extends StatefulWidget {
   final Function(String) onEdit;
   final Function(Section) onDelete;
   final Function(Section) onToggleStatus;
+  final Function(Section)? onManageItems;
 
   const FuturisticSectionsTable({
     super.key,
@@ -20,6 +21,7 @@ class FuturisticSectionsTable extends StatefulWidget {
     required this.onEdit,
     required this.onDelete,
     required this.onToggleStatus,
+    this.onManageItems,
   });
 
   @override
@@ -379,7 +381,7 @@ class _FuturisticSectionsTableState extends State<FuturisticSectionsTable> {
           _buildHeaderCell('الترتيب', 80),
           _buildHeaderCell('العناصر', 80),
           _buildHeaderCell('الحالة', 100),
-          _buildHeaderCell('الإجراءات', 150),
+          _buildHeaderCell('الإجراءات', 200),
         ],
       ),
     );
@@ -449,7 +451,7 @@ class _FuturisticSectionsTableState extends State<FuturisticSectionsTable> {
                 ),
               ),
               SizedBox(
-                width: 150,
+                width: 200,
                 child: _buildActions(section),
               ),
             ],
@@ -490,6 +492,13 @@ class _FuturisticSectionsTableState extends State<FuturisticSectionsTable> {
           tooltip: 'تعديل',
           color: AppTheme.primaryBlue,
         ),
+        if (widget.onManageItems != null)
+          _buildActionIcon(
+            icon: CupertinoIcons.square_stack_3d_down_right,
+            onTap: () => widget.onManageItems!(section),
+            tooltip: 'إدارة العناصر',
+            color: AppTheme.primaryPurple,
+          ),
         _buildActionIcon(
           icon: section.isActive
               ? CupertinoIcons.pause_circle


### PR DESCRIPTION
Add a "Manage Items" action button to the sections table to provide a missing UI entry point to `SectionItemsManagementPage`.

The `SectionItemsManagementPage` and its route were already defined, but there was no direct UI mechanism to navigate to it from the main sections list/table. This PR introduces a new action button in the `FuturisticSectionsTable` to enable this navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c393ca0-1ea9-4dc7-a191-9583b904cc18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c393ca0-1ea9-4dc7-a191-9583b904cc18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

