### PR TITLE
Analyze and fix image upload issue

### DIFF
--- a/backend/YemenBooking.Api/Controllers/Admin/PropertyInSectionImagesController.cs
+++ b/backend/YemenBooking.Api/Controllers/Admin/PropertyInSectionImagesController.cs
@@ -87,17 +87,23 @@ namespace YemenBooking.Api.Controllers.Admin
         /// </summary>
         [HttpGet]
         public async Task<IActionResult> Get(
-            [FromQuery] Guid? propertyInSectionId,
+            [FromQuery] string? propertyInSectionId,
             [FromQuery] string? tempKey,
             [FromQuery] string? sortBy = "order",
             [FromQuery] string? sortOrder = "asc",
             [FromQuery] int? page = 1, 
             [FromQuery] int? limit = 50)
         {
+            Guid? parsedId = null;
+            if (!string.IsNullOrWhiteSpace(propertyInSectionId) && Guid.TryParse(propertyInSectionId, out var id))
+            {
+                parsedId = id;
+            }
+
             var q = new GetPropertyInSectionImagesQuery 
             { 
-                PropertyInSectionId = propertyInSectionId,
-                TempKey = tempKey,
+                PropertyInSectionId = parsedId,
+                TempKey = string.IsNullOrWhiteSpace(tempKey) ? null : tempKey,
                 SortBy = sortBy,
                 SortOrder = sortOrder,
                 Page = page ?? 1, 

--- a/backend/YemenBooking.Api/Controllers/Admin/UnitInSectionImagesController.cs
+++ b/backend/YemenBooking.Api/Controllers/Admin/UnitInSectionImagesController.cs
@@ -87,17 +87,23 @@ namespace YemenBooking.Api.Controllers.Admin
         /// </summary>
         [HttpGet]
         public async Task<IActionResult> Get(
-            [FromQuery] Guid? unitInSectionId,
+            [FromQuery] string? unitInSectionId,
             [FromQuery] string? tempKey,
             [FromQuery] string? sortBy = "order",
             [FromQuery] string? sortOrder = "asc",
             [FromQuery] int? page = 1,
             [FromQuery] int? limit = 50)
         {
+            Guid? parsedId = null;
+            if (!string.IsNullOrWhiteSpace(unitInSectionId) && Guid.TryParse(unitInSectionId, out var id))
+            {
+                parsedId = id;
+            }
+
             var q = new GetUnitInSectionImagesQuery
             {
-                UnitInSectionId = unitInSectionId,
-                TempKey = tempKey,
+                UnitInSectionId = parsedId,
+                TempKey = string.IsNullOrWhiteSpace(tempKey) ? null : tempKey,
                 SortBy = sortBy,
                 SortOrder = sortOrder,
                 Page = page ?? 1,

--- a/control_panel_app/lib/features/admin_sections/data/datasources/property_in_section_images_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_sections/data/datasources/property_in_section_images_remote_datasource.dart
@@ -64,13 +64,17 @@ class PropertyInSectionImagesRemoteDataSourceImpl
         posterPath = await VideoUtils.generateVideoThumbnail(filePath);
       }
 
+      final normalizedPropertyInSectionId = (propertyInSectionId != null && propertyInSectionId.trim().isNotEmpty)
+          ? propertyInSectionId
+          : null;
+      final normalizedTempKey = (tempKey != null && tempKey.trim().isNotEmpty) ? tempKey : null;
       final formData = FormData.fromMap({
         'file': await MultipartFile.fromFile(filePath),
-        if (propertyInSectionId != null)
-          'propertyInSectionId': propertyInSectionId,
-        if (tempKey != null) 'tempKey': tempKey,
-        if (category != null) 'category': category,
-        if (alt != null) 'alt': alt,
+        if (normalizedPropertyInSectionId != null)
+          'propertyInSectionId': normalizedPropertyInSectionId,
+        if (normalizedTempKey != null) 'tempKey': normalizedTempKey,
+        if (category != null && category.trim().isNotEmpty) 'category': category,
+        if (alt != null && alt.trim().isNotEmpty) 'alt': alt,
         'isPrimary': isPrimary,
         if (order != null) 'order': order,
         if (tags != null && tags.isNotEmpty) 'tags': tags.join(','),
@@ -122,10 +126,14 @@ class PropertyInSectionImagesRemoteDataSourceImpl
     String? tempKey,
   }) async {
     try {
+      final normalizedPropertyInSectionId = (propertyInSectionId != null && propertyInSectionId.trim().isNotEmpty)
+          ? propertyInSectionId
+          : null;
+      final normalizedTempKey = (tempKey != null && tempKey.trim().isNotEmpty) ? tempKey : null;
       final qp = <String, dynamic>{
-        if (propertyInSectionId != null)
-          'propertyInSectionId': propertyInSectionId,
-        if (tempKey != null) 'tempKey': tempKey,
+        if (normalizedPropertyInSectionId != null)
+          'propertyInSectionId': normalizedPropertyInSectionId,
+        if (normalizedTempKey != null) 'tempKey': normalizedTempKey,
         'sortBy': 'order',
         'sortOrder': 'asc',
       };

--- a/control_panel_app/lib/features/admin_sections/data/datasources/unit_in_section_images_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_sections/data/datasources/unit_in_section_images_remote_datasource.dart
@@ -64,12 +64,16 @@ class UnitInSectionImagesRemoteDataSourceImpl
         posterPath = await VideoUtils.generateVideoThumbnail(filePath);
       }
 
+      final normalizedUnitInSectionId = (unitInSectionId != null && unitInSectionId.trim().isNotEmpty)
+          ? unitInSectionId
+          : null;
+      final normalizedTempKey = (tempKey != null && tempKey.trim().isNotEmpty) ? tempKey : null;
       final formData = FormData.fromMap({
         'file': await MultipartFile.fromFile(filePath),
-        if (unitInSectionId != null) 'unitInSectionId': unitInSectionId,
-        if (tempKey != null) 'tempKey': tempKey,
-        if (category != null) 'category': category,
-        if (alt != null) 'alt': alt,
+        if (normalizedUnitInSectionId != null) 'unitInSectionId': normalizedUnitInSectionId,
+        if (normalizedTempKey != null) 'tempKey': normalizedTempKey,
+        if (category != null && category.trim().isNotEmpty) 'category': category,
+        if (alt != null && alt.trim().isNotEmpty) 'alt': alt,
         'isPrimary': isPrimary,
         if (order != null) 'order': order,
         if (tags != null && tags.isNotEmpty) 'tags': tags.join(','),
@@ -122,9 +126,13 @@ class UnitInSectionImagesRemoteDataSourceImpl
     String? tempKey,
   }) async {
     try {
+      final normalizedUnitInSectionId = (unitInSectionId != null && unitInSectionId.trim().isNotEmpty)
+          ? unitInSectionId
+          : null;
+      final normalizedTempKey = (tempKey != null && tempKey.trim().isNotEmpty) ? tempKey : null;
       final qp = <String, dynamic>{
-        if (unitInSectionId != null) 'unitInSectionId': unitInSectionId,
-        if (tempKey != null) 'tempKey': tempKey,
+        if (normalizedUnitInSectionId != null) 'unitInSectionId': normalizedUnitInSectionId,
+        if (normalizedTempKey != null) 'tempKey': normalizedTempKey,
         'sortBy': 'order',
         'sortOrder': 'asc',
       };


### PR DESCRIPTION
Implement client-side input guards and harden backend GET endpoints to prevent server errors during image operations.

The issue stemmed from the client sending empty or invalid IDs (e.g., `propertyInSectionId`, `unitInSectionId`, `tempKey`) in subsequent GET requests after an image upload. While the upload itself might succeed, the backend would fail to parse these invalid string IDs into GUIDs, resulting in a 400 error and a 'server error' message to the user, even though the image was uploaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-500a7d54-2808-4eb7-a8a0-e19e34fda30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-500a7d54-2808-4eb7-a8a0-e19e34fda30e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

