### PR TITLE
Fix booking availability and cancellation bugs

### DIFF
--- a/control_panel_app/lib/features/admin_units/presentation/pages/edit_unit_page.dart
+++ b/control_panel_app/lib/features/admin_units/presentation/pages/edit_unit_page.dart
@@ -897,6 +897,7 @@ class _EditUnitPageState extends State<EditUnitPage>
                       _cancellationWindowDays = null;
                       _cancellationDaysController.text = '';
                     }
+                    _hasChanges = _checkForChanges();
                   });
                   _updateCancellationPolicy();
                 },
@@ -932,6 +933,7 @@ class _EditUnitPageState extends State<EditUnitPage>
                 onChanged: (value) {
                   setState(() {
                     _cancellationWindowDays = int.tryParse(value);
+                    _hasChanges = _checkForChanges();
                   });
                   _updateCancellationPolicy();
                 },
@@ -1898,7 +1900,13 @@ class _EditUnitPageState extends State<EditUnitPage>
     // التحقق من تغييرات الحقول الديناميكية
     final dynamicFieldsChanged = _checkDynamicFieldsChanges();
 
-    return basicFieldsChanged || imagesChanged || dynamicFieldsChanged;
+    // التحقق من تغييرات سياسة الإلغاء
+    final cancellationChanged =
+        _allowsCancellation != _originalUnit!.allowsCancellation ||
+            ((_cancellationWindowDays ?? -1) !=
+                (_originalUnit!.cancellationWindowDays ?? -1));
+
+    return basicFieldsChanged || imagesChanged || dynamicFieldsChanged || cancellationChanged;
   }
 
   // دالة للتحقق من تغييرات الحقول الديناميكية
@@ -1944,7 +1952,10 @@ class _EditUnitPageState extends State<EditUnitPage>
                 (_originalUnit!.adultsCapacity ?? _originalUnit!.maxCapacity) ||
             _childrenCapacity != (_originalUnit!.childrenCapacity ?? 0) ||
             _pricingMethod !=
-                _getPricingMethodString(_originalUnit!.pricingMethod);
+                _getPricingMethodString(_originalUnit!.pricingMethod) ||
+            _allowsCancellation != _originalUnit!.allowsCancellation ||
+            ((_cancellationWindowDays ?? -1) !=
+                (_originalUnit!.cancellationWindowDays ?? -1));
       case 2: // Features, Images & Dynamic Fields
         return _featuresController.text != _originalUnit!.customFeatures ||
             _imagesChanged ||
@@ -2051,6 +2062,13 @@ class _EditUnitPageState extends State<EditUnitPage>
                 _getPricingMethodString(_originalUnit!.pricingMethod);
             _existingImages = List<String>.from(_originalImages);
             _imagesChanged = false;
+
+            // إعادة تعيين سياسة الإلغاء
+            _allowsCancellation = _originalUnit!.allowsCancellation;
+            _cancellationWindowDays = _originalUnit!.cancellationWindowDays;
+            _cancellationDaysController.text = _cancellationWindowDays != null
+                ? _cancellationWindowDays.toString()
+                : '';
 
             // إعادة تعيين الحقول الديناميكية
             _dynamicFieldValues =


### PR DESCRIPTION
Fixes issues with cancellation policy not saving/displaying and "no changes" error in unit edit page.

The `_checkForChanges` and `_hasChangesInStep` methods in the Flutter app were updated to correctly track changes for the cancellation policy toggle and days. Additionally, `_hasChanges` is now recomputed when these fields are modified, and the reset function correctly restores the original cancellation policy values.

---
<a href="https://cursor.com/background-agent?bcId=bc-2cffd336-ae12-449a-8a3e-0f7248812dea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2cffd336-ae12-449a-8a3e-0f7248812dea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

