### PR TITLE
Setup and verify notifications feature

### DIFF
--- a/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
+++ b/control_panel_app/lib/features/admin_hub/presentation/pages/admin_hub_page.dart
@@ -1,12 +1,17 @@
 // lib/features/admin_hub/presentation/pages/admin_hub_page.dart
 
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
 import 'dart:ui';
 import 'package:flutter_staggered_animations/flutter_staggered_animations.dart';
 import '../../../../core/theme/app_theme.dart';
 import '../../../../core/theme/app_text_styles.dart';
+import '../../../notifications/presentation/bloc/notification_bloc.dart';
+import '../../../notifications/presentation/bloc/notification_event.dart';
+import '../../../notifications/presentation/bloc/notification_state.dart';
+import '../../../../injection_container.dart' as di;
 
 class AdminHubPage extends StatefulWidget {
   const AdminHubPage({super.key});
@@ -378,10 +383,23 @@ class _AdminHubPageState extends State<AdminHubPage>
         ),
 
         // Notifications
-        _buildAppBarAction(
-          icon: Icons.notifications_none_rounded,
-          onTap: () => context.push('/notifications'),
-          badge: '3',
+        BlocProvider<NotificationBloc>(
+          create: (_) => di.sl<NotificationBloc>()..add(const LoadUnreadCountEvent()),
+          child: BlocBuilder<NotificationBloc, NotificationState>(
+            builder: (context, state) {
+              String? badge;
+              if (state is NotificationLoaded) {
+                if (state.unreadCount > 0) badge = state.unreadCount > 99 ? '99+' : state.unreadCount.toString();
+              } else if (state is NotificationUnreadCountLoaded) {
+                if (state.unreadCount > 0) badge = state.unreadCount > 99 ? '99+' : state.unreadCount.toString();
+              }
+              return _buildAppBarAction(
+                icon: Icons.notifications_none_rounded,
+                onTap: () => context.push('/notifications'),
+                badge: badge,
+              );
+            },
+          ),
         ),
 
         // Profile
@@ -1352,10 +1370,23 @@ class _AdminHubPageState extends State<AdminHubPage>
                 // Quick Stats
                 Row(
                   children: [
-                    _buildMiniStat(
-                      icon: Icons.notifications_active,
-                      value: '3',
-                      color: AppTheme.warning,
+                    BlocProvider<NotificationBloc>(
+                      create: (_) => di.sl<NotificationBloc>()..add(const LoadUnreadCountEvent()),
+                      child: BlocBuilder<NotificationBloc, NotificationState>(
+                        builder: (context, state) {
+                          String value = '0';
+                          if (state is NotificationLoaded) {
+                            value = state.unreadCount.toString();
+                          } else if (state is NotificationUnreadCountLoaded) {
+                            value = state.unreadCount.toString();
+                          }
+                          return _buildMiniStat(
+                            icon: Icons.notifications_active,
+                            value: value,
+                            color: AppTheme.warning,
+                          );
+                        },
+                      ),
                     ),
                     const SizedBox(width: 16),
                     _buildMiniStat(

--- a/control_panel_app/lib/features/notifications/presentation/bloc/notification_bloc.dart
+++ b/control_panel_app/lib/features/notifications/presentation/bloc/notification_bloc.dart
@@ -76,7 +76,17 @@ class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
 
     await result.fold(
       (failure) async => emit(NotificationError(message: _mapFailureToMessage(failure))),
-      (_) async => emit(const NotificationOperationSuccess(message: 'Notification marked as read')),
+      (_) async {
+        emit(const NotificationOperationSuccess(message: 'Notification marked as read'));
+        // refresh unread count after marking as read
+        if (getUnreadCountUseCase != null) {
+          final unreadRes = await getUnreadCountUseCase!(const GetUnreadCountParams());
+          await unreadRes.fold(
+            (failure) async {},
+            (count) async => emit(NotificationUnreadCountLoaded(unreadCount: count)),
+          );
+        }
+      },
     );
   }
 
@@ -94,7 +104,16 @@ class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
 
     await result.fold(
       (failure) async => emit(NotificationError(message: _mapFailureToMessage(failure))),
-      (_) async => emit(const NotificationOperationSuccess(message: 'All notifications marked as read')),
+      (_) async {
+        emit(const NotificationOperationSuccess(message: 'All notifications marked as read'));
+        if (getUnreadCountUseCase != null) {
+          final unreadRes = await getUnreadCountUseCase!(const GetUnreadCountParams());
+          await unreadRes.fold(
+            (failure) async {},
+            (count) async => emit(NotificationUnreadCountLoaded(unreadCount: count)),
+          );
+        }
+      },
     );
   }
 
@@ -112,7 +131,16 @@ class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
 
     await result.fold(
       (failure) async => emit(NotificationError(message: _mapFailureToMessage(failure))),
-      (_) async => emit(const NotificationOperationSuccess(message: 'Notification dismissed')),
+      (_) async {
+        emit(const NotificationOperationSuccess(message: 'Notification dismissed'));
+        if (getUnreadCountUseCase != null) {
+          final unreadRes = await getUnreadCountUseCase!(const GetUnreadCountParams());
+          await unreadRes.fold(
+            (failure) async {},
+            (count) async => emit(NotificationUnreadCountLoaded(unreadCount: count)),
+          );
+        }
+      },
     );
   }
 
@@ -145,7 +173,7 @@ class NotificationBloc extends Bloc<NotificationEvent, NotificationState> {
     final result = await getUnreadCountUseCase!(const GetUnreadCountParams());
     await result.fold(
       (failure) async => emit(NotificationError(message: _mapFailureToMessage(failure))),
-      (count) async => emit(NotificationOperationSuccess(message: 'Unread count: $count')),
+      (count) async => emit(NotificationUnreadCountLoaded(unreadCount: count)),
     );
   }
 

--- a/control_panel_app/lib/features/notifications/presentation/bloc/notification_state.dart
+++ b/control_panel_app/lib/features/notifications/presentation/bloc/notification_state.dart
@@ -50,6 +50,16 @@ class NotificationLoaded extends NotificationState {
   }
 }
 
+/// State when only unread count is loaded/refreshed
+class NotificationUnreadCountLoaded extends NotificationState {
+  final int unreadCount;
+
+  const NotificationUnreadCountLoaded({required this.unreadCount});
+
+  @override
+  List<Object?> get props => [unreadCount];
+}
+
 /// State when notification settings are loaded
 class NotificationSettingsLoaded extends NotificationState {
   final Map<String, bool> settings;

--- a/control_panel_app/lib/features/notifications/presentation/pages/notification_settings_page.dart
+++ b/control_panel_app/lib/features/notifications/presentation/pages/notification_settings_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../injection_container.dart' as di;
+import '../../../settings/presentation/bloc/settings_bloc.dart' as st_bloc;
+import '../../../settings/presentation/bloc/settings_event.dart' as st_event;
+import '../../../settings/presentation/bloc/settings_state.dart' as st_state;
+
+class NotificationSettingsPage extends StatelessWidget {
+  const NotificationSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<st_bloc.SettingsBloc>(
+      create: (_) => di.sl<st_bloc.SettingsBloc>(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('إعدادات الإشعارات'),
+        ),
+        body: BlocBuilder<st_bloc.SettingsBloc, st_state.SettingsState>(
+          builder: (context, state) {
+            if (state is st_state.SettingsLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (state is st_state.SettingsLoaded || state is st_state.SettingsUpdated) {
+              final settings = state is st_state.SettingsLoaded
+                  ? state.settings
+                  : (state as st_state.SettingsUpdated).settings;
+              final notif = settings.notificationSettings;
+              return ListView(
+                children: [
+                  SwitchListTile(
+                    title: const Text('إشعارات الحجوزات'),
+                    value: notif['bookingNotifications'] ?? true,
+                    onChanged: (val) => _update(context, notif..['bookingNotifications'] = val),
+                  ),
+                  SwitchListTile(
+                    title: const Text('إشعارات ترويجية'),
+                    value: notif['promotionalNotifications'] ?? true,
+                    onChanged: (val) => _update(context, notif..['promotionalNotifications'] = val),
+                  ),
+                  SwitchListTile(
+                    title: const Text('إشعارات البريد الإلكتروني'),
+                    value: notif['emailNotifications'] ?? true,
+                    onChanged: (val) => _update(context, notif..['emailNotifications'] = val),
+                  ),
+                  SwitchListTile(
+                    title: const Text('إشعارات الرسائل القصيرة'),
+                    value: notif['smsNotifications'] ?? false,
+                    onChanged: (val) => _update(context, notif..['smsNotifications'] = val),
+                  ),
+                  SwitchListTile(
+                    title: const Text('الإشعارات الدفعية (Push)'),
+                    value: notif['pushNotifications'] ?? true,
+                    onChanged: (val) => _update(context, notif..['pushNotifications'] = val),
+                  ),
+                ],
+              );
+            }
+            if (state is st_state.SettingsError) {
+              return Center(child: Text(state.message));
+            }
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+
+  void _update(BuildContext context, Map<String, bool> newSettings) {
+    context.read<st_bloc.SettingsBloc>().add(
+          st_event.UpdateNotificationSettingsEvent(settings: Map<String, bool>.from(newSettings)),
+        );
+  }
+}
+

--- a/control_panel_app/lib/routes/app_router.dart
+++ b/control_panel_app/lib/routes/app_router.dart
@@ -112,6 +112,7 @@ import 'package:bookn_cp_app/features/onboarding/presentation/pages/select_city_
 import 'package:bookn_cp_app/features/notifications/presentation/pages/notifications_page.dart';
 import 'package:bookn_cp_app/features/notifications/presentation/pages/notification_settings_page.dart';
 import 'package:bookn_cp_app/features/admin_hub/presentation/pages/admin_hub_page.dart';
+import 'package:bookn_cp_app/features/notifications/presentation/bloc/notification_bloc.dart' as notif_bloc;
 import 'package:bookn_cp_app/features/settings/presentation/pages/language_settings_page.dart';
 import 'package:bookn_cp_app/features/settings/presentation/bloc/settings_bloc.dart'
     as st_bloc;
@@ -484,8 +485,12 @@ class AppRouter {
         // Admin Hub
         GoRoute(
           path: '/admin',
-          pageBuilder: (context, state) =>
-              scaleFadeTransitionPage(child: const AdminHubPage()),
+          pageBuilder: (context, state) => scaleFadeTransitionPage(
+            child: BlocProvider<notif_bloc.NotificationBloc>(
+              create: (_) => di.sl<notif_bloc.NotificationBloc>(),
+              child: const AdminHubPage(),
+            ),
+          ),
         ),
 
         // Admin Units - list
@@ -946,13 +951,21 @@ class AppRouter {
         // Notifications
         GoRoute(
           path: '/notifications',
-          pageBuilder: (context, state) =>
-              fadeTransitionPage(child: const NotificationsPage()),
+          pageBuilder: (context, state) => fadeTransitionPage(
+            child: BlocProvider<notif_bloc.NotificationBloc>(
+              create: (_) => di.sl<notif_bloc.NotificationBloc>()..add(const notif_bloc.LoadNotificationsEvent()),
+              child: const NotificationsPage(),
+            ),
+          ),
         ),
         GoRoute(
           path: '/notifications/settings',
-          pageBuilder: (context, state) =>
-              slideUpTransitionPage(child: const NotificationSettingsPage()),
+          pageBuilder: (context, state) => slideUpTransitionPage(
+            child: BlocProvider<st_bloc.SettingsBloc>(
+              create: (_) => di.sl<st_bloc.SettingsBloc>(),
+              child: const NotificationSettingsPage(),
+            ),
+          ),
         ),
 
         // Admin Cities


### PR DESCRIPTION
Update notification feature to display dynamic unread counts and add settings page.

The `AdminHubPage` now shows the actual unread notification count instead of a hardcoded value, and the count refreshes after mark-read/dismiss actions. A new `NotificationSettingsPage` has been added and wired into the `AppRouter` for managing notification preferences.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f3946cf-d334-4d68-b450-83268eed1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f3946cf-d334-4d68-b450-83268eed1494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

