### PR TITLE
Implement admin notifications feature

### DIFF
--- a/backend/YemenBooking.Api/Controllers/Admin/NotificationsController.cs
+++ b/backend/YemenBooking.Api/Controllers/Admin/NotificationsController.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using YemenBooking.Application.Commands.Notifications;
 using YemenBooking.Application.Queries.Notifications;
 using System;
+using YemenBooking.Application.DTOs;
 
 namespace YemenBooking.Api.Controllers.Admin
 {
@@ -22,6 +23,17 @@ namespace YemenBooking.Api.Controllers.Admin
         /// </summary>
         [HttpPost]
         public async Task<IActionResult> CreateNotification([FromBody] CreateNotificationCommand command)
+        {
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// بث إشعار لمجموعة مستخدمين
+        /// Broadcast a notification to users
+        /// </summary>
+        [HttpPost("broadcast")]
+        public async Task<ActionResult<ResultDto<int>>> Broadcast([FromBody] BroadcastNotificationCommand command)
         {
             var result = await _mediator.Send(command);
             return Ok(result);
@@ -46,6 +58,36 @@ namespace YemenBooking.Api.Controllers.Admin
         public async Task<IActionResult> GetUserNotifications(Guid userId, [FromQuery] GetUserNotificationsQuery query)
         {
             query.UserId = userId;
+            var result = await _mediator.Send(query);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// حذف إشعار
+        /// </summary>
+        [HttpDelete("{notificationId}")]
+        public async Task<ActionResult<ResultDto<bool>>> Delete(Guid notificationId)
+        {
+            var result = await _mediator.Send(new DeleteNotificationCommand { NotificationId = notificationId });
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// إعادة إرسال إشعار فاشل
+        /// </summary>
+        [HttpPost("{notificationId}/resend")]
+        public async Task<ActionResult<ResultDto<bool>>> Resend(Guid notificationId)
+        {
+            var result = await _mediator.Send(new ResendNotificationCommand { NotificationId = notificationId });
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// الحصول على إحصائيات الإشعارات
+        /// </summary>
+        [HttpGet("stats")]
+        public async Task<ActionResult<NotificationsStatsDto>> GetStats([FromQuery] GetNotificationsStatsQuery query)
+        {
             var result = await _mediator.Send(query);
             return Ok(result);
         }

--- a/backend/YemenBooking.Api/Program.cs
+++ b/backend/YemenBooking.Api/Program.cs
@@ -32,6 +32,7 @@ using Google.Apis.Auth.OAuth2;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.AspNetCore.Hosting;
 using System.IO;
+using YemenBooking.Infrastructure.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -204,6 +205,9 @@ builder.Services.AddSingleton<YemenBooking.Infrastructure.Indexing.Services.ILit
 });
 
 builder.Services.AddHostedService(provider => (YemenBooking.Infrastructure.Indexing.Services.QueuedLiteDbService)provider.GetRequiredService<YemenBooking.Infrastructure.Indexing.Services.ILiteDbWriteQueue>());
+
+// إشغّل مرسل الإشعارات المجدولة
+builder.Services.AddHostedService<ScheduledNotificationsDispatcher>();
 
 // IMPORTANT: IIndexingService depends on scoped repositories/services, so register it as Scoped
 builder.Services.AddScoped<IIndexingService>(provider =>

--- a/backend/YemenBooking.Application/Commands/CP/Notifications/BroadcastNotificationCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Notifications/BroadcastNotificationCommand.cs
@@ -1,0 +1,26 @@
+using MediatR;
+using YemenBooking.Application.DTOs;
+
+namespace YemenBooking.Application.Commands.Notifications
+{
+    /// <summary>
+    /// بث إشعار لمجموعة من المستخدمين حسب معايير اختيار
+    /// Broadcast notification to target users
+    /// </summary>
+    public class BroadcastNotificationCommand : IRequest<ResultDto<int>>
+    {
+        public string Type { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+
+        // Targeting
+        public bool TargetAllUsers { get; set; } = false;
+        public Guid[]? TargetUserIds { get; set; }
+        public string[]? TargetRoles { get; set; }
+
+        // Optional scheduling
+        public DateTime? ScheduledFor { get; set; }
+        public string Priority { get; set; } = "MEDIUM";
+    }
+}
+

--- a/backend/YemenBooking.Application/Commands/CP/Notifications/DeleteNotificationCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Notifications/DeleteNotificationCommand.cs
@@ -1,0 +1,15 @@
+using MediatR;
+using YemenBooking.Application.DTOs;
+
+namespace YemenBooking.Application.Commands.Notifications
+{
+    /// <summary>
+    /// حذف إشعار
+    /// Delete notification
+    /// </summary>
+    public class DeleteNotificationCommand : IRequest<ResultDto<bool>>
+    {
+        public Guid NotificationId { get; set; }
+    }
+}
+

--- a/backend/YemenBooking.Application/Commands/CP/Notifications/ResendNotificationCommand.cs
+++ b/backend/YemenBooking.Application/Commands/CP/Notifications/ResendNotificationCommand.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using YemenBooking.Application.DTOs;
+
+namespace YemenBooking.Application.Commands.Notifications
+{
+    /// <summary>
+    /// إعادة إرسال إشعار فشل سابقًا
+    /// Resend a previously failed notification
+    /// </summary>
+    public class ResendNotificationCommand : IRequest<ResultDto<bool>>
+    {
+        public Guid NotificationId { get; set; }
+        public string? Channel { get; set; } // IN_APP/EMAIL/SMS/PUSH (optional)
+    }
+}
+

--- a/backend/YemenBooking.Application/DTOs/NotificationsStatsDto.cs
+++ b/backend/YemenBooking.Application/DTOs/NotificationsStatsDto.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace YemenBooking.Application.DTOs
+{
+    /// <summary>
+    /// إحصائيات الإشعارات المعروضة في لوحة الإدارة
+    /// Notifications statistics for admin dashboard
+    /// </summary>
+    public class NotificationsStatsDto
+    {
+        public int Total { get; set; }
+        public int Pending { get; set; }
+        public int Sent { get; set; }
+        public int Delivered { get; set; }
+        public int Read { get; set; }
+        public int Failed { get; set; }
+
+        public int Today { get; set; }
+        public int Last7Days { get; set; }
+        public int Last30Days { get; set; }
+    }
+}
+

--- a/backend/YemenBooking.Application/Handlers/Commands/Notifications/BroadcastNotificationCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Notifications/BroadcastNotificationCommandHandler.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using YemenBooking.Application.Commands.Notifications;
+using YemenBooking.Application.DTOs;
+using YemenBooking.Core.Entities;
+using YemenBooking.Core.Interfaces;
+using YemenBooking.Core.Interfaces.Repositories;
+
+namespace YemenBooking.Application.Handlers.Commands.Notifications
+{
+    /// <summary>
+    /// معالج بث الإشعارات للمستخدمين المستهدفين
+    /// </summary>
+    public class BroadcastNotificationCommandHandler : IRequestHandler<BroadcastNotificationCommand, ResultDto<int>>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IUserRepository _userRepository;
+        private readonly ILogger<BroadcastNotificationCommandHandler> _logger;
+
+        public BroadcastNotificationCommandHandler(
+            IUnitOfWork unitOfWork,
+            IUserRepository userRepository,
+            ILogger<BroadcastNotificationCommandHandler> logger)
+        {
+            _unitOfWork = unitOfWork;
+            _userRepository = userRepository;
+            _logger = logger;
+        }
+
+        public async Task<ResultDto<int>> Handle(BroadcastNotificationCommand request, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(request.Title) || string.IsNullOrWhiteSpace(request.Message) || string.IsNullOrWhiteSpace(request.Type))
+                return ResultDto<int>.Failed("النوع والعنوان والمحتوى مطلوبة");
+
+            // Resolve recipients
+            var recipients = Enumerable.Empty<User>();
+            if (request.TargetAllUsers)
+            {
+                recipients = await _userRepository.GetAllUsersAsync(cancellationToken);
+            }
+            else if (request.TargetUserIds != null && request.TargetUserIds.Length > 0)
+            {
+                var ids = request.TargetUserIds.Distinct().ToArray();
+                var queryable = _userRepository.GetQueryable();
+                recipients = queryable.Where(u => ids.Contains(u.Id)).ToList();
+            }
+            else
+            {
+                return ResultDto<int>.Failed("لم يتم تحديد المستلمين");
+            }
+
+            var now = DateTime.UtcNow;
+            var notifications = recipients.Select(u => new Notification
+            {
+                RecipientId = u.Id,
+                Type = request.Type,
+                Title = request.Title,
+                Message = request.Message,
+                Priority = request.Priority,
+                Status = request.ScheduledFor.HasValue ? "PENDING" : "PENDING",
+                ScheduledFor = request.ScheduledFor,
+                CreatedAt = now
+            }).ToList();
+
+            await _unitOfWork.Repository<Notification>().AddRangeAsync(notifications, cancellationToken);
+            var inserted = notifications.Count;
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("تم إنشاء {Count} إشعار للبث", inserted);
+            return ResultDto<int>.Succeeded(inserted, $"تم إنشاء {inserted} إشعار");
+        }
+    }
+}
+

--- a/backend/YemenBooking.Application/Handlers/Commands/Notifications/DeleteNotificationCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Notifications/DeleteNotificationCommandHandler.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using YemenBooking.Application.Commands.Notifications;
+using YemenBooking.Application.DTOs;
+using YemenBooking.Core.Interfaces;
+
+namespace YemenBooking.Application.Handlers.Commands.Notifications
+{
+    /// <summary>
+    /// معالج حذف الإشعار
+    /// </summary>
+    public class DeleteNotificationCommandHandler : IRequestHandler<DeleteNotificationCommand, ResultDto<bool>>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly ILogger<DeleteNotificationCommandHandler> _logger;
+
+        public DeleteNotificationCommandHandler(IUnitOfWork unitOfWork, ILogger<DeleteNotificationCommandHandler> logger)
+        {
+            _unitOfWork = unitOfWork;
+            _logger = logger;
+        }
+
+        public async Task<ResultDto<bool>> Handle(DeleteNotificationCommand request, CancellationToken cancellationToken)
+        {
+            if (request.NotificationId == Guid.Empty)
+                return ResultDto<bool>.Failed("معرف الإشعار مطلوب");
+
+            var repo = _unitOfWork.Repository<Core.Entities.Notification>();
+            var entity = await repo.GetByIdAsync(request.NotificationId, cancellationToken);
+            if (entity == null) return ResultDto<bool>.Failed("الإشعار غير موجود");
+
+            await repo.DeleteAsync(entity, cancellationToken);
+            await _unitOfWork.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("تم حذف الإشعار {NotificationId}", request.NotificationId);
+            return ResultDto<bool>.Succeeded(true, "تم حذف الإشعار");
+        }
+    }
+}
+

--- a/backend/YemenBooking.Application/Handlers/Commands/Notifications/ResendNotificationCommandHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Commands/Notifications/ResendNotificationCommandHandler.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using YemenBooking.Application.Commands.Notifications;
+using YemenBooking.Application.DTOs;
+using YemenBooking.Application.Interfaces.Services;
+using YemenBooking.Core.Entities;
+using YemenBooking.Core.Interfaces;
+
+namespace YemenBooking.Application.Handlers.Commands.Notifications
+{
+    /// <summary>
+    /// معالج إعادة إرسال إشعار فشل سابقًا
+    /// </summary>
+    public class ResendNotificationCommandHandler : IRequestHandler<ResendNotificationCommand, ResultDto<bool>>
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly INotificationService _notificationService;
+        private readonly ILogger<ResendNotificationCommandHandler> _logger;
+
+        public ResendNotificationCommandHandler(
+            IUnitOfWork unitOfWork,
+            INotificationService notificationService,
+            ILogger<ResendNotificationCommandHandler> logger)
+        {
+            _unitOfWork = unitOfWork;
+            _notificationService = notificationService;
+            _logger = logger;
+        }
+
+        public async Task<ResultDto<bool>> Handle(ResendNotificationCommand request, CancellationToken cancellationToken)
+        {
+            if (request.NotificationId == Guid.Empty)
+                return ResultDto<bool>.Failed("معرف الإشعار مطلوب");
+
+            var repo = _unitOfWork.Repository<Notification>();
+            var entity = await repo.GetByIdAsync(request.NotificationId, cancellationToken);
+            if (entity == null)
+                return ResultDto<bool>.Failed("الإشعار غير موجود");
+
+            try
+            {
+                await _notificationService.SendAsync(new YemenBooking.Core.Notifications.NotificationRequest
+                {
+                    UserId = entity.RecipientId,
+                    Title = entity.Title,
+                    Message = entity.Message,
+                    Type = Enum.TryParse<YemenBooking.Core.Notifications.NotificationType>(entity.Type, true, out var t)
+                        ? t : YemenBooking.Core.Notifications.NotificationType.BookingUpdated,
+                    Data = string.IsNullOrWhiteSpace(entity.Data) ? null : JsonSerializer.Deserialize<object>(entity.Data)
+                }, cancellationToken);
+
+                entity.MarkAsSent(request.Channel ?? "IN_APP");
+                await repo.UpdateAsync(entity, cancellationToken);
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+                return ResultDto<bool>.Succeeded(true, "تمت إعادة إرسال الإشعار");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "فشل إعادة إرسال الإشعار {NotificationId}", request.NotificationId);
+                entity.MarkAsFailed(ex.Message);
+                await repo.UpdateAsync(entity, cancellationToken);
+                await _unitOfWork.SaveChangesAsync(cancellationToken);
+                return ResultDto<bool>.Failed("فشل إعادة إرسال الإشعار");
+            }
+        }
+    }
+}
+

--- a/backend/YemenBooking.Application/Handlers/Queries/Notifications/GetNotificationsStatsQueryHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Queries/Notifications/GetNotificationsStatsQueryHandler.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using YemenBooking.Application.DTOs;
+using YemenBooking.Application.Queries.Notifications;
+using YemenBooking.Core.Entities;
+using YemenBooking.Core.Interfaces.Repositories;
+using YemenBooking.Application.Interfaces;
+
+namespace YemenBooking.Application.Handlers.Queries.Notifications
+{
+    /// <summary>
+    /// معالج إحصائيات الإشعارات
+    /// </summary>
+    public class GetNotificationsStatsQueryHandler : IRequestHandler<GetNotificationsStatsQuery, NotificationsStatsDto>
+    {
+        private readonly INotificationRepository _notificationRepository;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly ILogger<GetNotificationsStatsQueryHandler> _logger;
+
+        public GetNotificationsStatsQueryHandler(
+            INotificationRepository notificationRepository,
+            ICurrentUserService currentUserService,
+            ILogger<GetNotificationsStatsQueryHandler> logger)
+        {
+            _notificationRepository = notificationRepository;
+            _currentUserService = currentUserService;
+            _logger = logger;
+        }
+
+        public async Task<NotificationsStatsDto> Handle(GetNotificationsStatsQuery request, CancellationToken cancellationToken)
+        {
+            if (_currentUserService.Role != "Admin")
+                return new NotificationsStatsDto();
+
+            var q = _notificationRepository.GetQueryable();
+            if (!string.IsNullOrWhiteSpace(request.Type)) q = q.Where(n => n.Type == request.Type);
+            if (request.From.HasValue) q = q.Where(n => n.CreatedAt >= request.From.Value);
+            if (request.To.HasValue) q = q.Where(n => n.CreatedAt <= request.To.Value);
+
+            var now = DateTime.UtcNow.Date;
+            var last7 = now.AddDays(-7);
+            var last30 = now.AddDays(-30);
+
+            var stats = new NotificationsStatsDto
+            {
+                Total = q.Count(),
+                Pending = q.Count(n => n.Status == "PENDING"),
+                Sent = q.Count(n => n.Status == "SENT"),
+                Delivered = q.Count(n => n.Status == "DELIVERED"),
+                Read = q.Count(n => n.Status == "READ"),
+                Failed = q.Count(n => n.Status == "FAILED"),
+                Today = q.Count(n => n.CreatedAt >= now),
+                Last7Days = q.Count(n => n.CreatedAt >= last7),
+                Last30Days = q.Count(n => n.CreatedAt >= last30)
+            };
+
+            return await Task.FromResult(stats);
+        }
+    }
+}
+

--- a/backend/YemenBooking.Application/Queries/CP/Notifications/GetNotificationsStatsQuery.cs
+++ b/backend/YemenBooking.Application/Queries/CP/Notifications/GetNotificationsStatsQuery.cs
@@ -1,0 +1,16 @@
+using MediatR;
+using YemenBooking.Application.DTOs;
+
+namespace YemenBooking.Application.Queries.Notifications
+{
+    /// <summary>
+    /// استعلام إحصائيات الإشعارات للوحة الإدارة
+    /// </summary>
+    public class GetNotificationsStatsQuery : IRequest<NotificationsStatsDto>
+    {
+        public string? Type { get; set; }
+        public DateTime? From { get; set; }
+        public DateTime? To { get; set; }
+    }
+}
+

--- a/backend/YemenBooking.Infrastructure/Services/ScheduledNotificationsDispatcher.cs
+++ b/backend/YemenBooking.Infrastructure/Services/ScheduledNotificationsDispatcher.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using YemenBooking.Application.Interfaces.Services;
+using YemenBooking.Core.Entities;
+using YemenBooking.Infrastructure.Data.Context;
+
+namespace YemenBooking.Infrastructure.Services
+{
+    /// <summary>
+    /// خدمة مستضافة ترسل الإشعارات المجدولة أو المعلقة بشكل دوري
+    /// Background dispatcher to send scheduled/pending notifications
+    /// </summary>
+    public class ScheduledNotificationsDispatcher : BackgroundService
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ILogger<ScheduledNotificationsDispatcher> _logger;
+
+        public ScheduledNotificationsDispatcher(IServiceProvider serviceProvider, ILogger<ScheduledNotificationsDispatcher> logger)
+        {
+            _serviceProvider = serviceProvider;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("ScheduledNotificationsDispatcher started");
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    using var scope = _serviceProvider.CreateScope();
+                    var db = scope.ServiceProvider.GetRequiredService<YemenBookingDbContext>();
+                    var notifier = scope.ServiceProvider.GetRequiredService<INotificationService>();
+
+                    var now = DateTime.UtcNow;
+                    var due = await db.Set<Notification>()
+                        .Where(n => n.Status == "PENDING" && (!n.ScheduledFor.HasValue || n.ScheduledFor <= now) && !n.IsDeleted)
+                        .OrderBy(n => n.CreatedAt)
+                        .Take(100)
+                        .ToListAsync(stoppingToken);
+
+                    foreach (var n in due)
+                    {
+                        try
+                        {
+                            await notifier.SendAsync(new YemenBooking.Core.Notifications.NotificationRequest
+                            {
+                                UserId = n.RecipientId,
+                                Title = n.Title,
+                                Message = n.Message,
+                                Type = Enum.TryParse<YemenBooking.Core.Notifications.NotificationType>(n.Type, true, out var t)
+                                    ? t : YemenBooking.Core.Notifications.NotificationType.BookingUpdated,
+                                Data = string.IsNullOrWhiteSpace(n.Data) ? null : JsonSerializer.Deserialize<object>(n.Data)
+                            }, stoppingToken);
+                            n.MarkAsSent("IN_APP");
+                            n.MarkAsDelivered();
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex, "Failed to dispatch notification {Id}", n.Id);
+                            n.MarkAsFailed(ex.Message);
+                        }
+                    }
+
+                    if (due.Count > 0)
+                        await db.SaveChangesAsync(stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error in ScheduledNotificationsDispatcher loop");
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+            }
+        }
+    }
+}
+

--- a/control_panel_app/lib/features/admin_notifications/data/datasources/admin_notifications_remote_datasource.dart
+++ b/control_panel_app/lib/features/admin_notifications/data/datasources/admin_notifications_remote_datasource.dart
@@ -1,0 +1,109 @@
+import 'package:bookn_cp_app/core/models/paginated_result.dart';
+import 'package:bookn_cp_app/core/network/api_client.dart';
+import '../../domain/entities/admin_notification.dart';
+import '../models/admin_notification_model.dart';
+
+class AdminNotificationsRemoteDataSource {
+  final ApiClient apiClient;
+  AdminNotificationsRemoteDataSource({required this.apiClient});
+
+  Future<String> create({
+    required String type,
+    required String title,
+    required String message,
+    required String recipientId,
+  }) async {
+    final res = await apiClient.post('/api/admin/notifications', data: {
+      'type': type,
+      'title': title,
+      'message': message,
+      'recipientId': recipientId,
+    });
+    return (res.data['data'] ?? res.data['result']).toString();
+  }
+
+  Future<int> broadcast({
+    required String type,
+    required String title,
+    required String message,
+    bool targetAll = false,
+    List<String>? userIds,
+    List<String>? roles,
+    DateTime? scheduledFor,
+  }) async {
+    final res = await apiClient.post('/api/admin/notifications/broadcast', data: {
+      'type': type,
+      'title': title,
+      'message': message,
+      'targetAllUsers': targetAll,
+      if (userIds != null) 'targetUserIds': userIds,
+      if (roles != null) 'targetRoles': roles,
+      if (scheduledFor != null) 'scheduledFor': scheduledFor.toUtc().toIso8601String(),
+    });
+    return (res.data['data'] ?? res.data['result']) as int;
+  }
+
+  Future<bool> delete(String notificationId) async {
+    final res = await apiClient.delete('/api/admin/notifications/$notificationId');
+    return (res.data['data'] ?? res.data['result']) as bool? ?? true;
+  }
+
+  Future<bool> resend(String notificationId) async {
+    final res = await apiClient.post('/api/admin/notifications/$notificationId/resend');
+    return (res.data['data'] ?? res.data['result']) as bool? ?? true;
+  }
+
+  Future<PaginatedResult<AdminNotificationEntity>> getSystem({
+    int page = 1,
+    int pageSize = 20,
+    String? type,
+    String? status,
+  }) async {
+    final res = await apiClient.get('/api/admin/notifications', queryParameters: {
+      'pageNumber': page,
+      'pageSize': pageSize,
+      if (type != null) 'notificationType': type,
+      if (status != null) 'status': status,
+    });
+    final data = res.data;
+    final items = (data['items'] as List)
+        .map((e) => AdminNotificationModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return PaginatedResult(
+      items: items,
+      pageNumber: data['pageNumber'] ?? page,
+      pageSize: data['pageSize'] ?? pageSize,
+      totalCount: data['totalCount'] ?? items.length,
+    );
+  }
+
+  Future<PaginatedResult<AdminNotificationEntity>> getUser({
+    required String userId,
+    int page = 1,
+    int pageSize = 20,
+    bool? isRead,
+  }) async {
+    final res = await apiClient.get('/api/admin/notifications/user/$userId', queryParameters: {
+      'pageNumber': page,
+      'pageSize': pageSize,
+      if (isRead != null) 'isRead': isRead,
+    });
+    final data = res.data;
+    final items = (data['items'] as List)
+        .map((e) => AdminNotificationModel.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return PaginatedResult(
+      items: items,
+      pageNumber: data['pageNumber'] ?? page,
+      pageSize: data['pageSize'] ?? pageSize,
+      totalCount: data['totalCount'] ?? items.length,
+    );
+  }
+
+  Future<Map<String, int>> getStats() async {
+    final res = await apiClient.get('/api/admin/notifications/stats');
+    final data = Map<String, dynamic>.from(res.data as Map);
+    return data.map((key, value) => MapEntry(key, (value as num).toInt()));
+  }
+}
+

--- a/control_panel_app/lib/features/admin_notifications/data/models/admin_notification_model.dart
+++ b/control_panel_app/lib/features/admin_notifications/data/models/admin_notification_model.dart
@@ -1,0 +1,32 @@
+import '../../domain/entities/admin_notification.dart';
+
+class AdminNotificationModel extends AdminNotificationEntity {
+  AdminNotificationModel({
+    required super.id,
+    required super.type,
+    required super.title,
+    required super.message,
+    required super.status,
+    required super.priority,
+    required super.recipientId,
+    required super.isRead,
+    required super.createdAt,
+    super.readAt,
+  });
+
+  factory AdminNotificationModel.fromJson(Map<String, dynamic> json) {
+    return AdminNotificationModel(
+      id: json['id'] as String,
+      type: json['type'] as String,
+      title: json['title'] as String,
+      message: json['message'] as String,
+      status: json['status'] as String,
+      priority: json['priority'] as String,
+      recipientId: json['recipientId'] as String,
+      isRead: json['isRead'] as bool? ?? false,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      readAt: json['readAt'] != null ? DateTime.tryParse(json['readAt'] as String) : null,
+    );
+  }
+}
+

--- a/control_panel_app/lib/features/admin_notifications/data/repositories/admin_notifications_repository_impl.dart
+++ b/control_panel_app/lib/features/admin_notifications/data/repositories/admin_notifications_repository_impl.dart
@@ -1,0 +1,99 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../../../core/models/paginated_result.dart';
+import '../../domain/entities/admin_notification.dart';
+import '../../domain/repositories/admin_notifications_repository.dart';
+import '../datasources/admin_notifications_remote_datasource.dart';
+
+class AdminNotificationsRepositoryImpl implements AdminNotificationsRepository {
+  final AdminNotificationsRemoteDataSource remote;
+  final NetworkInfo networkInfo;
+  AdminNotificationsRepositoryImpl({required this.remote, required this.networkInfo});
+
+  @override
+  Future<Either<Failure, String>> create({required String type, required String title, required String message, required String recipientId}) async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final id = await remote.create(type: type, title: title, message: message, recipientId: recipientId);
+      return Right(id);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, int>> broadcast({required String type, required String title, required String message, bool targetAll = false, List<String>? userIds, List<String>? roles, DateTime? scheduledFor}) async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final count = await remote.broadcast(
+        type: type,
+        title: title,
+        message: message,
+        targetAll: targetAll,
+        userIds: userIds,
+        roles: roles,
+        scheduledFor: scheduledFor,
+      );
+      return Right(count);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> delete(String notificationId) async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final ok = await remote.delete(notificationId);
+      return Right(ok);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, PaginatedResult<AdminNotificationEntity>>> getSystem({int page = 1, int pageSize = 20, String? type, String? status}) async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final res = await remote.getSystem(page: page, pageSize: pageSize, type: type, status: status);
+      return Right(res);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, PaginatedResult<AdminNotificationEntity>>> getUser({required String userId, int page = 1, int pageSize = 20, bool? isRead}) async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final res = await remote.getUser(userId: userId, page: page, pageSize: pageSize, isRead: isRead);
+      return Right(res);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, bool>> resend(String notificationId) async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final ok = await remote.resend(notificationId);
+      return Right(ok);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+
+  @override
+  Future<Either<Failure, Map<String, int>>> getStats() async {
+    if (!await networkInfo.isConnected) return Left(NetworkFailure());
+    try {
+      final res = await remote.getStats();
+      return Right(res);
+    } catch (e) {
+      return Left(ServerFailure(message: e.toString()));
+    }
+  }
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/entities/admin_notification.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/entities/admin_notification.dart
@@ -1,0 +1,26 @@
+class AdminNotificationEntity {
+  final String id;
+  final String type;
+  final String title;
+  final String message;
+  final String status;
+  final String priority;
+  final String recipientId;
+  final bool isRead;
+  final DateTime createdAt;
+  final DateTime? readAt;
+
+  AdminNotificationEntity({
+    required this.id,
+    required this.type,
+    required this.title,
+    required this.message,
+    required this.status,
+    required this.priority,
+    required this.recipientId,
+    required this.isRead,
+    required this.createdAt,
+    this.readAt,
+  });
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/repositories/admin_notifications_repository.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/repositories/admin_notifications_repository.dart
@@ -1,0 +1,44 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/models/paginated_result.dart';
+import '../entities/admin_notification.dart';
+
+abstract class AdminNotificationsRepository {
+  Future<Either<Failure, String>> create({
+    required String type,
+    required String title,
+    required String message,
+    required String recipientId,
+  });
+
+  Future<Either<Failure, int>> broadcast({
+    required String type,
+    required String title,
+    required String message,
+    bool targetAll = false,
+    List<String>? userIds,
+    List<String>? roles,
+    DateTime? scheduledFor,
+  });
+
+  Future<Either<Failure, bool>> delete(String notificationId);
+
+  Future<Either<Failure, bool>> resend(String notificationId);
+
+  Future<Either<Failure, PaginatedResult<AdminNotificationEntity>>> getSystem({
+    int page = 1,
+    int pageSize = 20,
+    String? type,
+    String? status,
+  });
+
+  Future<Either<Failure, PaginatedResult<AdminNotificationEntity>>> getUser({
+    required String userId,
+    int page = 1,
+    int pageSize = 20,
+    bool? isRead,
+  });
+
+  Future<Either<Failure, Map<String, int>>> getStats();
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/broadcast_notification_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/broadcast_notification_usecase.dart
@@ -1,0 +1,27 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../../../../core/error/failures.dart';
+
+class BroadcastAdminNotificationUseCase {
+  final AdminNotificationsRepository repository;
+  BroadcastAdminNotificationUseCase(this.repository);
+
+  Future<Either<Failure, int>> call({
+    required String type,
+    required String title,
+    required String message,
+    bool targetAll = false,
+    List<String>? userIds,
+    List<String>? roles,
+    DateTime? scheduledFor,
+  }) => repository.broadcast(
+        type: type,
+        title: title,
+        message: message,
+        targetAll: targetAll,
+        userIds: userIds,
+        roles: roles,
+        scheduledFor: scheduledFor,
+      );
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/create_notification_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/create_notification_usecase.dart
@@ -1,0 +1,16 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../../../../core/error/failures.dart';
+
+class CreateAdminNotificationUseCase {
+  final AdminNotificationsRepository repository;
+  CreateAdminNotificationUseCase(this.repository);
+
+  Future<Either<Failure, String>> call({
+    required String type,
+    required String title,
+    required String message,
+    required String recipientId,
+  }) => repository.create(type: type, title: title, message: message, recipientId: recipientId);
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/delete_notification_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/delete_notification_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../../../../core/error/failures.dart';
+
+class DeleteAdminNotificationUseCase {
+  final AdminNotificationsRepository repository;
+  DeleteAdminNotificationUseCase(this.repository);
+
+  Future<Either<Failure, bool>> call(String notificationId) => repository.delete(notificationId);
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/get_notifications_stats_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/get_notifications_stats_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../../../../core/error/failures.dart';
+
+class GetAdminNotificationsStatsUseCase {
+  final AdminNotificationsRepository repository;
+  GetAdminNotificationsStatsUseCase(this.repository);
+
+  Future<Either<Failure, Map<String, int>>> call() => repository.getStats();
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/get_system_notifications_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/get_system_notifications_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../entities/admin_notification.dart';
+import '../../../../../core/error/failures.dart';
+import '../../../../../core/models/paginated_result.dart';
+
+class GetSystemAdminNotificationsUseCase {
+  final AdminNotificationsRepository repository;
+  GetSystemAdminNotificationsUseCase(this.repository);
+
+  Future<Either<Failure, PaginatedResult<AdminNotificationEntity>>> call({
+    int page = 1,
+    int pageSize = 20,
+    String? type,
+    String? status,
+  }) => repository.getSystem(page: page, pageSize: pageSize, type: type, status: status);
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/get_user_notifications_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/get_user_notifications_usecase.dart
@@ -1,0 +1,18 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../entities/admin_notification.dart';
+import '../../../../../core/error/failures.dart';
+import '../../../../../core/models/paginated_result.dart';
+
+class GetUserAdminNotificationsUseCase {
+  final AdminNotificationsRepository repository;
+  GetUserAdminNotificationsUseCase(this.repository);
+
+  Future<Either<Failure, PaginatedResult<AdminNotificationEntity>>> call({
+    required String userId,
+    int page = 1,
+    int pageSize = 20,
+    bool? isRead,
+  }) => repository.getUser(userId: userId, page: page, pageSize: pageSize, isRead: isRead);
+}
+

--- a/control_panel_app/lib/features/admin_notifications/domain/usecases/resend_notification_usecase.dart
+++ b/control_panel_app/lib/features/admin_notifications/domain/usecases/resend_notification_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:dartz/dartz.dart';
+import '../../repositories/admin_notifications_repository.dart';
+import '../../../../../core/error/failures.dart';
+
+class ResendAdminNotificationUseCase {
+  final AdminNotificationsRepository repository;
+  ResendAdminNotificationUseCase(this.repository);
+
+  Future<Either<Failure, bool>> call(String notificationId) => repository.resend(notificationId);
+}
+

--- a/control_panel_app/lib/features/admin_notifications/presentation/bloc/admin_notifications_bloc.dart
+++ b/control_panel_app/lib/features/admin_notifications/presentation/bloc/admin_notifications_bloc.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/usecases/create_notification_usecase.dart';
+import '../../domain/usecases/broadcast_notification_usecase.dart';
+import '../../domain/usecases/delete_notification_usecase.dart';
+import '../../domain/usecases/resend_notification_usecase.dart';
+import '../../domain/usecases/get_system_notifications_usecase.dart';
+import '../../domain/usecases/get_user_notifications_usecase.dart';
+import '../../domain/usecases/get_notifications_stats_usecase.dart';
+import 'admin_notifications_event.dart';
+import 'admin_notifications_state.dart';
+
+class AdminNotificationsBloc extends Bloc<AdminNotificationsEvent, AdminNotificationsState> {
+  final CreateAdminNotificationUseCase createUseCase;
+  final BroadcastAdminNotificationUseCase broadcastUseCase;
+  final DeleteAdminNotificationUseCase deleteUseCase;
+  final ResendAdminNotificationUseCase resendUseCase;
+  final GetSystemAdminNotificationsUseCase getSystemUseCase;
+  final GetUserAdminNotificationsUseCase getUserUseCase;
+  final GetAdminNotificationsStatsUseCase getStatsUseCase;
+
+  AdminNotificationsBloc({
+    required this.createUseCase,
+    required this.broadcastUseCase,
+    required this.deleteUseCase,
+    required this.resendUseCase,
+    required this.getSystemUseCase,
+    required this.getUserUseCase,
+    required this.getStatsUseCase,
+  }) : super(const AdminNotificationsInitial()) {
+    on<LoadSystemNotificationsEvent>((event, emit) async {
+      emit(const AdminNotificationsLoading());
+      final res = await getSystemUseCase(page: event.page, pageSize: event.pageSize, type: event.type, status: event.status);
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل تحميل إشعارات النظام')),
+        (r) => emit(AdminSystemNotificationsLoaded(items: r.items, totalCount: r.totalCount)),
+      );
+    });
+
+    on<LoadUserNotificationsEvent>((event, emit) async {
+      emit(const AdminNotificationsLoading());
+      final res = await getUserUseCase(userId: event.userId, page: event.page, pageSize: event.pageSize, isRead: event.isRead);
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل تحميل إشعارات المستخدم')),
+        (r) => emit(AdminUserNotificationsLoaded(items: r.items, totalCount: r.totalCount)),
+      );
+    });
+
+    on<CreateAdminNotificationEvent>((event, emit) async {
+      final res = await createUseCase(type: event.type, title: event.title, message: event.message, recipientId: event.recipientId);
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل إنشاء الإشعار')),
+        (r) => emit(const AdminNotificationsSuccess('تم إنشاء الإشعار')),
+      );
+    });
+
+    on<BroadcastAdminNotificationEvent>((event, emit) async {
+      final res = await broadcastUseCase(
+        type: event.type,
+        title: event.title,
+        message: event.message,
+        targetAll: event.targetAll,
+        userIds: event.userIds,
+        roles: event.roles,
+        scheduledFor: event.scheduledFor,
+      );
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل بث الإشعار')),
+        (r) => emit(AdminNotificationsSuccess('تم بث الإشعار لعدد $r مستخدم')),
+      );
+    });
+
+    on<DeleteAdminNotificationEvent>((event, emit) async {
+      final res = await deleteUseCase(event.notificationId);
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل حذف الإشعار')),
+        (r) => emit(const AdminNotificationsSuccess('تم حذف الإشعار')),
+      );
+    });
+
+    on<ResendAdminNotificationEvent>((event, emit) async {
+      final res = await resendUseCase(event.notificationId);
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل إعادة إرسال الإشعار')),
+        (r) => emit(const AdminNotificationsSuccess('تمت إعادة الإرسال')),
+      );
+    });
+
+    on<LoadAdminNotificationsStatsEvent>((event, emit) async {
+      final res = await getStatsUseCase();
+      res.fold(
+        (l) => emit(AdminNotificationsError(l.message ?? 'فشل تحميل الإحصائيات')),
+        (r) => emit(AdminNotificationsStatsLoaded(r)),
+      );
+    });
+  }
+}
+

--- a/control_panel_app/lib/features/admin_notifications/presentation/bloc/admin_notifications_event.dart
+++ b/control_panel_app/lib/features/admin_notifications/presentation/bloc/admin_notifications_event.dart
@@ -1,0 +1,61 @@
+abstract class AdminNotificationsEvent {
+  const AdminNotificationsEvent();
+}
+
+class LoadSystemNotificationsEvent extends AdminNotificationsEvent {
+  final int page;
+  final int pageSize;
+  final String? type;
+  final String? status;
+  const LoadSystemNotificationsEvent({this.page = 1, this.pageSize = 20, this.type, this.status});
+}
+
+class LoadUserNotificationsEvent extends AdminNotificationsEvent {
+  final String userId;
+  final int page;
+  final int pageSize;
+  final bool? isRead;
+  const LoadUserNotificationsEvent({required this.userId, this.page = 1, this.pageSize = 20, this.isRead});
+}
+
+class CreateAdminNotificationEvent extends AdminNotificationsEvent {
+  final String type;
+  final String title;
+  final String message;
+  final String recipientId;
+  const CreateAdminNotificationEvent({required this.type, required this.title, required this.message, required this.recipientId});
+}
+
+class BroadcastAdminNotificationEvent extends AdminNotificationsEvent {
+  final String type;
+  final String title;
+  final String message;
+  final bool targetAll;
+  final List<String>? userIds;
+  final List<String>? roles;
+  final DateTime? scheduledFor;
+  const BroadcastAdminNotificationEvent({
+    required this.type,
+    required this.title,
+    required this.message,
+    this.targetAll = false,
+    this.userIds,
+    this.roles,
+    this.scheduledFor,
+  });
+}
+
+class DeleteAdminNotificationEvent extends AdminNotificationsEvent {
+  final String notificationId;
+  const DeleteAdminNotificationEvent(this.notificationId);
+}
+
+class ResendAdminNotificationEvent extends AdminNotificationsEvent {
+  final String notificationId;
+  const ResendAdminNotificationEvent(this.notificationId);
+}
+
+class LoadAdminNotificationsStatsEvent extends AdminNotificationsEvent {
+  const LoadAdminNotificationsStatsEvent();
+}
+

--- a/control_panel_app/lib/features/admin_notifications/presentation/bloc/admin_notifications_state.dart
+++ b/control_panel_app/lib/features/admin_notifications/presentation/bloc/admin_notifications_state.dart
@@ -1,0 +1,42 @@
+import '../../../notifications/domain/entities/notification.dart' as common_notif;
+import '../../domain/entities/admin_notification.dart';
+
+abstract class AdminNotificationsState {
+  const AdminNotificationsState();
+}
+
+class AdminNotificationsInitial extends AdminNotificationsState {
+  const AdminNotificationsInitial();
+}
+
+class AdminNotificationsLoading extends AdminNotificationsState {
+  const AdminNotificationsLoading();
+}
+
+class AdminSystemNotificationsLoaded extends AdminNotificationsState {
+  final List<AdminNotificationEntity> items;
+  final int totalCount;
+  const AdminSystemNotificationsLoaded({required this.items, required this.totalCount});
+}
+
+class AdminUserNotificationsLoaded extends AdminNotificationsState {
+  final List<AdminNotificationEntity> items;
+  final int totalCount;
+  const AdminUserNotificationsLoaded({required this.items, required this.totalCount});
+}
+
+class AdminNotificationsStatsLoaded extends AdminNotificationsState {
+  final Map<String, int> stats;
+  const AdminNotificationsStatsLoaded(this.stats);
+}
+
+class AdminNotificationsSuccess extends AdminNotificationsState {
+  final String message;
+  const AdminNotificationsSuccess(this.message);
+}
+
+class AdminNotificationsError extends AdminNotificationsState {
+  final String message;
+  const AdminNotificationsError(this.message);
+}
+

--- a/control_panel_app/lib/features/admin_notifications/presentation/pages/admin_notifications_page.dart
+++ b/control_panel_app/lib/features/admin_notifications/presentation/pages/admin_notifications_page.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/entities/admin_notification.dart';
+import '../bloc/admin_notifications_bloc.dart';
+import '../bloc/admin_notifications_event.dart';
+import '../bloc/admin_notifications_state.dart';
+
+class AdminNotificationsPage extends StatelessWidget {
+  const AdminNotificationsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('إدارة الإشعارات')), 
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Navigator.of(context).push(MaterialPageRoute(builder: (_) => _CreateOneOffNotificationScreen()));
+        },
+        child: const Icon(Icons.add),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Row(
+              children: [
+                ElevatedButton.icon(
+                  onPressed: () => context.read<AdminNotificationsBloc>().add(const LoadAdminNotificationsStatsEvent()),
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('تحديث الإحصائيات'),
+                ),
+                const SizedBox(width: 12),
+                ElevatedButton.icon(
+                  onPressed: () => context.read<AdminNotificationsBloc>().add(const LoadSystemNotificationsEvent()),
+                  icon: const Icon(Icons.list),
+                  label: const Text('تحميل الإشعارات'),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: BlocBuilder<AdminNotificationsBloc, AdminNotificationsState>(
+              builder: (context, state) {
+                if (state is AdminNotificationsLoading) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (state is AdminNotificationsStatsLoaded) {
+                  final s = state.stats;
+                  return Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Wrap(
+                      spacing: 16,
+                      runSpacing: 16,
+                      children: s.entries.map((e) => _StatChip(label: e.key, value: e.value)).toList(),
+                    ),
+                  );
+                }
+                if (state is AdminSystemNotificationsLoaded) {
+                  return _NotificationsList(items: state.items);
+                }
+                return const Center(child: Text('')); 
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NotificationsList extends StatelessWidget {
+  final List<AdminNotificationEntity> items;
+  const _NotificationsList({required this.items});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      itemCount: items.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (context, index) {
+        final n = items[index];
+        return ListTile(
+          title: Text(n.title),
+          subtitle: Text(n.message),
+          trailing: Text(n.status),
+        );
+      },
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  final String label;
+  final int value;
+  const _StatChip({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(label: Text('$label: $value'));
+  }
+}
+
+class _CreateOneOffNotificationScreen extends StatefulWidget {
+  @override
+  State<_CreateOneOffNotificationScreen> createState() => _CreateOneOffNotificationScreenState();
+}
+
+class _CreateOneOffNotificationScreenState extends State<_CreateOneOffNotificationScreen> {
+  final _titleCtrl = TextEditingController();
+  final _msgCtrl = TextEditingController();
+  final _userCtrl = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('إنشاء إشعار')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(controller: _titleCtrl, decoration: const InputDecoration(labelText: 'العنوان')),
+            TextField(controller: _msgCtrl, decoration: const InputDecoration(labelText: 'المحتوى')),
+            TextField(controller: _userCtrl, decoration: const InputDecoration(labelText: 'معرف المستلم UUID')),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                context.read<AdminNotificationsBloc>().add(
+                      CreateAdminNotificationEvent(
+                        type: 'BookingUpdated',
+                        title: _titleCtrl.text,
+                        message: _msgCtrl.text,
+                        recipientId: _userCtrl.text,
+                      ),
+                    );
+                Navigator.pop(context);
+              },
+              child: const Text('إرسال'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/control_panel_app/lib/features/admin_notifications/presentation/pages/create_admin_notification_page.dart
+++ b/control_panel_app/lib/features/admin_notifications/presentation/pages/create_admin_notification_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/admin_notifications_bloc.dart';
+import '../bloc/admin_notifications_event.dart';
+
+class CreateAdminNotificationPage extends StatefulWidget {
+  const CreateAdminNotificationPage({super.key});
+
+  @override
+  State<CreateAdminNotificationPage> createState() => _CreateAdminNotificationPageState();
+}
+
+class _CreateAdminNotificationPageState extends State<CreateAdminNotificationPage> {
+  final _titleCtrl = TextEditingController();
+  final _msgCtrl = TextEditingController();
+  final _userCtrl = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('إنشاء إشعار')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(controller: _titleCtrl, decoration: const InputDecoration(labelText: 'العنوان')),
+            TextField(controller: _msgCtrl, decoration: const InputDecoration(labelText: 'المحتوى')),
+            TextField(controller: _userCtrl, decoration: const InputDecoration(labelText: 'معرف المستلم UUID')),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                context.read<AdminNotificationsBloc>().add(
+                      CreateAdminNotificationEvent(
+                        type: 'BookingUpdated',
+                        title: _titleCtrl.text,
+                        message: _msgCtrl.text,
+                        recipientId: _userCtrl.text,
+                      ),
+                    );
+                Navigator.pop(context);
+              },
+              child: const Text('إرسال'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/control_panel_app/lib/injection_container.dart
+++ b/control_panel_app/lib/injection_container.dart
@@ -663,6 +663,18 @@ import 'features/admin_payments/domain/usecases/analytics/get_refund_statistics_
 import 'package:bookn_cp_app/features/admin_payments/presentation/bloc/payment_analytics/payment_analytics_bloc.dart'
     as pay_an_bloc;
 import 'package:bookn_cp_app/features/auth/verification/bloc/email_verification_bloc.dart';
+// Admin Notifications
+import 'features/admin_notifications/presentation/bloc/admin_notifications_bloc.dart' as an_bloc;
+import 'features/admin_notifications/domain/repositories/admin_notifications_repository.dart' as an_repo;
+import 'features/admin_notifications/data/repositories/admin_notifications_repository_impl.dart' as an_repo_impl;
+import 'features/admin_notifications/data/datasources/admin_notifications_remote_datasource.dart' as an_ds_remote;
+import 'features/admin_notifications/domain/usecases/create_notification_usecase.dart' as an_uc_create;
+import 'features/admin_notifications/domain/usecases/broadcast_notification_usecase.dart' as an_uc_broadcast;
+import 'features/admin_notifications/domain/usecases/delete_notification_usecase.dart' as an_uc_delete;
+import 'features/admin_notifications/domain/usecases/resend_notification_usecase.dart' as an_uc_resend;
+import 'features/admin_notifications/domain/usecases/get_system_notifications_usecase.dart' as an_uc_get_system;
+import 'features/admin_notifications/domain/usecases/get_user_notifications_usecase.dart' as an_uc_get_user;
+import 'features/admin_notifications/domain/usecases/get_notifications_stats_usecase.dart' as an_uc_stats;
 
 final sl = GetIt.instance;
 
@@ -731,6 +743,9 @@ Future<void> init() async {
 
   // Features - Admin Sections
   _initAdminSections();
+
+  // Features - Admin Notifications
+  _initAdminNotifications();
 
   // Theme
   _initTheme();
@@ -2061,4 +2076,32 @@ Future<void> _initExternal() async {
             AddressCheckOptions(
                 address: io.InternetAddress.tryParse('8.8.8.8')!, port: 53),
           ]));
+}
+
+void _initAdminNotifications() {
+  // Bloc
+  sl.registerFactory(() => an_bloc.AdminNotificationsBloc(
+        createUseCase: sl<an_uc_create.CreateAdminNotificationUseCase>(),
+        broadcastUseCase: sl<an_uc_broadcast.BroadcastAdminNotificationUseCase>(),
+        deleteUseCase: sl<an_uc_delete.DeleteAdminNotificationUseCase>(),
+        resendUseCase: sl<an_uc_resend.ResendAdminNotificationUseCase>(),
+        getSystemUseCase: sl<an_uc_get_system.GetSystemAdminNotificationsUseCase>(),
+        getUserUseCase: sl<an_uc_get_user.GetUserAdminNotificationsUseCase>(),
+        getStatsUseCase: sl<an_uc_stats.GetAdminNotificationsStatsUseCase>(),
+      ));
+
+  // Use cases
+  sl.registerLazySingleton<an_uc_create.CreateAdminNotificationUseCase>(() => an_uc_create.CreateAdminNotificationUseCase(sl()));
+  sl.registerLazySingleton<an_uc_broadcast.BroadcastAdminNotificationUseCase>(() => an_uc_broadcast.BroadcastAdminNotificationUseCase(sl()));
+  sl.registerLazySingleton<an_uc_delete.DeleteAdminNotificationUseCase>(() => an_uc_delete.DeleteAdminNotificationUseCase(sl()));
+  sl.registerLazySingleton<an_uc_resend.ResendAdminNotificationUseCase>(() => an_uc_resend.ResendAdminNotificationUseCase(sl()));
+  sl.registerLazySingleton<an_uc_get_system.GetSystemAdminNotificationsUseCase>(() => an_uc_get_system.GetSystemAdminNotificationsUseCase(sl()));
+  sl.registerLazySingleton<an_uc_get_user.GetUserAdminNotificationsUseCase>(() => an_uc_get_user.GetUserAdminNotificationsUseCase(sl()));
+  sl.registerLazySingleton<an_uc_stats.GetAdminNotificationsStatsUseCase>(() => an_uc_stats.GetAdminNotificationsStatsUseCase(sl()));
+
+  // Repository
+  sl.registerLazySingleton<an_repo.AdminNotificationsRepository>(() => an_repo_impl.AdminNotificationsRepositoryImpl(remote: sl(), networkInfo: sl()));
+
+  // Data source
+  sl.registerLazySingleton<an_ds_remote.AdminNotificationsRemoteDataSource>(() => an_ds_remote.AdminNotificationsRemoteDataSource(apiClient: sl()));
 }

--- a/control_panel_app/lib/routes/app_router.dart
+++ b/control_panel_app/lib/routes/app_router.dart
@@ -185,6 +185,8 @@ import 'package:bookn_cp_app/features/admin_sections/presentation/bloc/section_f
 import 'package:bookn_cp_app/features/admin_sections/presentation/bloc/section_items/section_items_bloc.dart'
     as sec_items_bloc;
 import 'package:bookn_cp_app/core/enums/section_target.dart' as sec_enums;
+import 'package:bookn_cp_app/features/admin_notifications/presentation/bloc/admin_notifications_bloc.dart' as an_bloc;
+import 'package:bookn_cp_app/features/admin_notifications/presentation/pages/admin_notifications_page.dart';
 
 class AppRouter {
   static GoRouter build(BuildContext context) {
@@ -493,6 +495,17 @@ class AppRouter {
               child: const AdminHubPage(),
             ),
           ),
+        ),
+
+        // Admin Notifications
+        GoRoute(
+          path: '/admin/notifications',
+          builder: (context, state) {
+            return BlocProvider<an_bloc.AdminNotificationsBloc>(
+              create: (_) => di.sl<an_bloc.AdminNotificationsBloc>(),
+              child: const AdminNotificationsPage(),
+            );
+          },
         ),
 
         // Admin Units - list

--- a/control_panel_app/mobileAppPlan.md
+++ b/control_panel_app/mobileAppPlan.md
@@ -1070,6 +1070,42 @@ lib/
 │               ├─ settings_item_widget.dart
 │               └─ theme_selector_widget.dart
 │
+│
+│   ├── admin_notifications/
+│   │   ├── data/
+│   │   │   ├── datasources/
+│   │   │   │   └── admin_notifications_remote_datasource.dart
+│   │   │   ├── models/
+│   │   │   │   └── admin_notification_model.dart
+│   │   │   └── repositories/
+│   │   │       └── admin_notifications_repository_impl.dart
+│   │   ├── domain/
+│   │   │   ├── entities/
+│   │   │   │   └── admin_notification.dart
+│   │   │   ├── repositories/
+│   │   │   │   └── admin_notifications_repository.dart
+│   │   │   └── usecases/
+│   │   │       ├── create_notification_usecase.dart
+│   │   │       ├── broadcast_notification_usecase.dart
+│   │   │       ├── delete_notification_usecase.dart
+│   │   │       ├── resend_notification_usecase.dart
+│   │   │       ├── get_system_notifications_usecase.dart
+│   │   │       ├── get_user_notifications_usecase.dart
+│   │   │       └── get_notifications_stats_usecase.dart
+│   │   └── presentation/
+│   │       ├── bloc/
+│   │       │   ├── admin_notifications_bloc.dart
+│   │       │   ├── admin_notifications_event.dart
+│   │       │   └── admin_notifications_state.dart
+│   │       ├── pages/
+│   │       │   ├── admin_notifications_page.dart
+│   │       │   ├── create_admin_notification_page.dart
+│   │       │   └── user_notifications_page.dart
+│   │       └── widgets/
+│   │           ├── notification_filters_bar.dart
+│   │           ├── notifications_stats_card.dart
+│   │           ├── admin_notification_form.dart
+│   │           └── admin_notifications_table.dart
 ├── routes/
 │   ├── app_router.dart
 │   ├── route_animations.dart


### PR DESCRIPTION
Implement the `admin_notifications` feature to allow administrators to manage, broadcast, and track notifications from the control panel.

This PR introduces backend endpoints for broadcasting, deleting, resending, and querying notification statistics, along with a background service for scheduled delivery. It also adds the full `admin_notifications` module to the Flutter control panel app, including data, domain, and presentation layers, DI setup, and routing.

---
<a href="https://cursor.com/background-agent?bcId=bc-4732cfe6-ffbd-431a-a3e8-bd9387964388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4732cfe6-ffbd-431a-a3e8-bd9387964388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

