### PR TITLE
Fix firebase notification delivery for control panel and booking apps

### DIFF
--- a/control_panel_app/android/app/src/main/AndroidManifest.xml
+++ b/control_panel_app/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Android 13+ notifications runtime permission -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Camera and media/gallery permissions -->
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Android 13+ photo picker/read images permission -->
@@ -18,6 +20,16 @@
         android:usesCleartextTraffic="true"
         android:networkSecurityConfig="@xml/network_security_config"
         android:enableOnBackInvokedCallback="true">
+        <!-- Default FCM notification channel and icon -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="yemen_booking_channel" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@mipmap/ic_launcher" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@android:color/black" />
         <!-- Google Maps API Key -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/yemen_booking_app/android/app/src/main/AndroidManifest.xml
+++ b/yemen_booking_app/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- Android 13+ notifications runtime permission -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- Camera and media/gallery permissions -->
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Android 13+ photo picker/read images permission -->
@@ -16,6 +18,16 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:enableOnBackInvokedCallback="true">
+        <!-- Default FCM notification channel and icon -->
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="yemen_booking_channel" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@mipmap/ic_launcher" />
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@android:color/black" />
         <!-- Google Maps API Key -->
         <meta-data
             android:name="com.google.android.geo.API_KEY"


### PR DESCRIPTION
Fix FCM notifications not being received or displayed by adding Android 13+ permission, configuring default channels, and correcting handler registration.

The primary reasons for notifications not being received or displayed were the absence of the Android 13+ `POST_NOTIFICATIONS` runtime permission request, and the lack of a `default_notification_channel_id` in `AndroidManifest.xml` for Android 8+ devices. This PR addresses these issues, enables foreground notification presentation for iOS, and logs the FCM token for easier testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-63d4bf9a-23ee-4847-8e81-2763c8ad4e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63d4bf9a-23ee-4847-8e81-2763c8ad4e36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

