### PR TITLE
Setup role-based firebase notification channels

### DIFF
--- a/control_panel_app/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/control_panel_app/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -12,6 +12,8 @@ import '../../domain/usecases/upload_user_image_usecase.dart';
 import '../../domain/usecases/change_password_usecase.dart';
 import 'auth_event.dart';
 import 'auth_state.dart';
+import '../../../../services/notification_service.dart';
+import '../../../../injection_container.dart' as di;
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final LoginUseCase loginUseCase;
@@ -130,6 +132,10 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     await result.fold(
       (failure) async => emit(AuthError(message: _mapFailureToMessage(failure))),
       (_) async {
+        // Unregister FCM and unsubscribe topics
+        try {
+          await di.sl<NotificationService>().unregisterFcmToken();
+        } catch (_) {}
         emit(const AuthLogoutSuccess());
         emit(const AuthUnauthenticated());
       },

--- a/control_panel_app/lib/services/notification_service.dart
+++ b/control_panel_app/lib/services/notification_service.dart
@@ -138,9 +138,69 @@ class NotificationService {
         debugPrint('FCM token: $token');
         await _sendTokenToServer(token);
         await _localStorage?.saveFcmToken(token);
+        await _subscribeToDefaultTopics();
       }
     } catch (e) {
       debugPrint('Error registering FCM token: $e');
+    }
+  }
+
+  // Subscribe to default topics: all, user_{id}, role_*
+  Future<void> _subscribeToDefaultTopics() async {
+    try {
+      await _firebaseMessaging.subscribeToTopic('all');
+      final user = await _authLocalDataSource?.getCachedUser();
+      if (user != null) {
+        final String userId = user.userId?.toString() ?? '';
+        if (userId.isNotEmpty) {
+          await _firebaseMessaging.subscribeToTopic('user_${userId}');
+        }
+        // roles may come from user.roles and accountRole
+        final List<String> roles = []
+          ..addAll(((user.roles ?? []) as List).map((e) => e.toString()))
+          ..addAll((user.accountRole != null && (user.accountRole as String).isNotEmpty)
+              ? [user.accountRole as String]
+              : const <String>[]);
+        final uniqueRoles = roles
+            .where((r) => r.trim().isNotEmpty)
+            .map((r) => r.trim().toLowerCase())
+            .toSet()
+            .toList();
+        for (final role in uniqueRoles) {
+          await _firebaseMessaging.subscribeToTopic('role_${role}');
+        }
+      }
+    } catch (e) {
+      debugPrint('Error subscribing to default topics: $e');
+    }
+  }
+
+  // Unsubscribe from default topics: all, user_{id}, role_*
+  Future<void> _unsubscribeFromDefaultTopics() async {
+    try {
+      await _firebaseMessaging.unsubscribeFromTopic('all');
+      final user = await _authLocalDataSource?.getCachedUser();
+      if (user != null) {
+        final String userId = user.userId?.toString() ?? '';
+        if (userId.isNotEmpty) {
+          await _firebaseMessaging.unsubscribeFromTopic('user_${userId}');
+        }
+        final List<String> roles = []
+          ..addAll(((user.roles ?? []) as List).map((e) => e.toString()))
+          ..addAll((user.accountRole != null && (user.accountRole as String).isNotEmpty)
+              ? [user.accountRole as String]
+              : const <String>[]);
+        final uniqueRoles = roles
+            .where((r) => r.trim().isNotEmpty)
+            .map((r) => r.trim().toLowerCase())
+            .toSet()
+            .toList();
+        for (final role in uniqueRoles) {
+          await _firebaseMessaging.unsubscribeFromTopic('role_${role}');
+        }
+      }
+    } catch (e) {
+      debugPrint('Error unsubscribing from default topics: $e');
     }
   }
 
@@ -172,6 +232,7 @@ class NotificationService {
     debugPrint('FCM token refreshed: $token');
     await _sendTokenToServer(token);
     await _localStorage?.saveFcmToken(token);
+    await _subscribeToDefaultTopics();
   }
 
   // Unregister FCM token
@@ -191,6 +252,7 @@ class NotificationService {
         },
       );
 
+      await _unsubscribeFromDefaultTopics();
       await _firebaseMessaging.deleteToken();
     } catch (e) {
       debugPrint('Error unregistering FCM token: $e');


### PR DESCRIPTION
Implement FCM topic-based notifications for efficient broadcast messaging to all users, specific roles, or individual users.

The previous notification system sent individual messages to each user, which is inefficient for broadcasts. This change leverages FCM topics (`all`, `user_{id}`, `role_{role}`) to enable scalable broadcast notifications from the backend, as requested by the user. It also ensures proper topic management on app login/logout.

---
<a href="https://cursor.com/background-agent?bcId=bc-580041a8-38d7-4071-a05a-a3655e70a6ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-580041a8-38d7-4071-a05a-a3655e70a6ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

