### PR TITLE
Implement role-based chat restrictions with FCM

### DIFF
--- a/backend/YemenBooking.Application/Handlers/Queries/Chat/GetAvailableUsersQueryHandler.cs
+++ b/backend/YemenBooking.Application/Handlers/Queries/Chat/GetAvailableUsersQueryHandler.cs
@@ -11,6 +11,8 @@ namespace YemenBooking.Application.Handlers.Queries.Chat
     using YemenBooking.Application.DTOs;
     using YemenBooking.Application.Queries.Chat;
     using YemenBooking.Core.Interfaces.Repositories;
+    using YemenBooking.Application.Interfaces.Services;
+    using System;
 
     /// <summary>
     /// معالج استعلام جلب قائمة المستخدمين المتاحين للمحادثة
@@ -19,12 +21,16 @@ namespace YemenBooking.Application.Handlers.Queries.Chat
     public class GetAvailableUsersQueryHandler : IRequestHandler<GetAvailableUsersQuery, ResultDto<IEnumerable<ChatUserDto>>>
     {
         private readonly IUserRepository _userRepo;
+        private readonly IChatConversationRepository _chatRepo;
+        private readonly ICurrentUserService _currentUser;
         private readonly IMapper _mapper;
 
-        public GetAvailableUsersQueryHandler(IUserRepository userRepo, IMapper mapper)
+        public GetAvailableUsersQueryHandler(IUserRepository userRepo, IChatConversationRepository chatRepo, IMapper mapper, ICurrentUserService currentUser)
         {
             _userRepo = userRepo;
+            _chatRepo = chatRepo;
             _mapper = mapper;
+            _currentUser = currentUser;
         }
 
         public async Task<ResultDto<IEnumerable<ChatUserDto>>> Handle(GetAvailableUsersQuery request, CancellationToken cancellationToken)
@@ -32,12 +38,60 @@ namespace YemenBooking.Application.Handlers.Queries.Chat
             IQueryable<YemenBooking.Core.Entities.User> query = _userRepo.GetQueryable().AsNoTracking();
             query = query.Include(u => u.UserRoles).ThenInclude(ur => ur.Role);
             query = query.Include(u => u.Properties);
+            
+            // Role-based filtering for available contacts list
+            var roles = (_currentUser.UserRoles ?? Enumerable.Empty<string>()).Select(r => (r ?? string.Empty).ToLowerInvariant()).ToList();
+            var accountRole = (_currentUser.AccountRole ?? string.Empty).ToLowerInvariant();
+            var isAdmin = roles.Contains("admin") || roles.Contains("super_admin") || accountRole == "admin";
+            var isOwner = roles.Contains("owner") || roles.Contains("hotel_owner") || accountRole == "owner";
+            var isStaff = roles.Contains("staff") || roles.Contains("hotel_manager") || roles.Contains("receptionist") || accountRole == "staff";
+            var isClient = roles.Contains("client") || roles.Contains("customer") || accountRole == "client";
 
-            if (!string.IsNullOrEmpty(request.UserType))
-                query = query.Where(u => u.UserRoles.Any(ur => ur.Role != null && ur.Role.Name.ToLower() == request.UserType.ToLower()));
-
-            if (request.PropertyId.HasValue)
-                query = query.Where(u => u.Properties.Any(p => p.Id == request.PropertyId));
+            if (isAdmin)
+            {
+                // Admin: قائمة كاملة بجميع المستخدمين (يمكن تضييقها بالـ request.UserType إن وُجد)
+                if (!string.IsNullOrEmpty(request.UserType))
+                    query = query.Where(u => u.UserRoles.Any(ur => ur.Role != null && ur.Role.Name.ToLower() == request.UserType.ToLower()));
+            }
+            else if (isOwner || isStaff)
+            {
+                // Owner/Staff: حساب مراسلة واحد (العقار). يمكنهم رؤية:
+                // - حسابات الأدمن
+                // - العملاء الذين سبق أن راسلوا هذا العقار
+                var propertyId = _currentUser.PropertyId;
+                if (propertyId.HasValue)
+                {
+                    var pid = propertyId.Value;
+                    var propertyParticipantIds = _chatRepo.GetQueryable()
+                        .Where(c => c.PropertyId.HasValue && c.PropertyId.Value == pid)
+                        .SelectMany(c => c.Participants.Select(p => p.Id));
+                    query = query.Where(u =>
+                        u.UserRoles.Any(ur => ur.Role != null && (ur.Role.Name.ToLower() == "admin" || ur.Role.Name.ToLower() == "super_admin"))
+                        || propertyParticipantIds.Contains(u.Id));
+                }
+                else
+                {
+                    // إن لم يوجد PropertyId، فلا جهات اتصال
+                    query = query.Where(u => false);
+                }
+            }
+            else if (isClient)
+            {
+                // Client: يمكنه مراسلة الأدمن والعقارات التي سبق مراسلتها فقط حتى تظهر في القائمة
+                // لإضافة عقار جديد، يبدأ محادثة عبر شاشة العقار وليس من قائمة جهات الاتصال
+                var currentUserId = _currentUser.UserId;
+                var chattedPropertyParticipantIds = _chatRepo.GetQueryable()
+                    .Where(c => c.PropertyId.HasValue && c.Participants.Any(p => p.Id == currentUserId))
+                    .SelectMany(c => c.Participants.Select(p => p.Id));
+                query = query.Where(u =>
+                    u.UserRoles.Any(ur => ur.Role != null && (ur.Role.Name.ToLower() == "admin" || ur.Role.Name.ToLower() == "super_admin"))
+                    || chattedPropertyParticipantIds.Contains(u.Id));
+            }
+            else
+            {
+                // أدوار أخرى: لا شيء
+                query = query.Where(u => false);
+            }
 
             var users = await query.ToListAsync(cancellationToken);
             var dtos = _mapper.Map<IEnumerable<ChatUserDto>>(users);

--- a/backend/YemenBooking.Core/Interfaces/Repositories/IChatConversationRepository.cs
+++ b/backend/YemenBooking.Core/Interfaces/Repositories/IChatConversationRepository.cs
@@ -29,5 +29,17 @@ namespace YemenBooking.Core.Interfaces.Repositories
         /// Get conversation by id including participants and messages
         /// </summary>
         Task<ChatConversation?> GetByIdWithDetailsAsync(Guid id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// الحصول على المحادثات المرتبطة بعقار محدد (حساب المراسلة الخاص بالعقار)
+        /// Get conversations associated with a specific property (property-level messaging account)
+        /// </summary>
+        Task<(IEnumerable<ChatConversation> Items, int TotalCount)> GetConversationsByPropertyAsync(Guid propertyId, int page, int pageSize, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// التحقق من وجود محادثة سابقة بين عميل وعقار محدد
+        /// Check whether a prior conversation exists between a client user and a specific property
+        /// </summary>
+        Task<bool> ExistsConversationBetweenClientAndPropertyAsync(Guid clientUserId, Guid propertyId, CancellationToken cancellationToken = default);
     }
 } 


### PR DESCRIPTION
Implement role-based chat constraints and conversation visibility to enforce specific communication rules for Admin, Owner/Staff, and Client users.

Owner/Staff users are restricted to property-level messaging, allowing communication only with Admins or clients who have previously initiated a conversation with their property. Client users can message Admins or properties they have previously interacted with, with new property conversations initiated via the property screen rather than the general contact list.

---
<a href="https://cursor.com/background-agent?bcId=bc-02b3c1d7-6790-4bda-b032-44c3fa497e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02b3c1d7-6790-4bda-b032-44c3fa497e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

