### PR TITLE
Refactor chat system for reactions and read receipts using FCM

### DIFF
--- a/control_panel_app/lib/features/chat/presentation/bloc/chat_bloc.dart
+++ b/control_panel_app/lib/features/chat/presentation/bloc/chat_bloc.dart
@@ -1034,7 +1034,7 @@ class ChatBloc extends Bloc<ChatEvent, ChatState> {
           final m = msgs[i];
           if (m.id == event.messageId) {
             final reactions = m.reactions
-                .where((r) => r.reactionType != event.reactionType)
+                .where((r) => !(r.reactionType == event.reactionType && (event.currentUserId == null || r.userId == event.currentUserId)))
                 .toList();
             msgs[i] = Message(
               id: m.id,

--- a/control_panel_app/lib/features/chat/presentation/bloc/chat_event.dart
+++ b/control_panel_app/lib/features/chat/presentation/bloc/chat_event.dart
@@ -165,14 +165,16 @@ class AddReactionEvent extends ChatEvent {
 class RemoveReactionEvent extends ChatEvent {
   final String messageId;
   final String reactionType;
+  final String? currentUserId; // لمعالجة الإزالة المتفائلة بدقة
 
   const RemoveReactionEvent({
     required this.messageId,
     required this.reactionType,
+    this.currentUserId,
   });
 
   @override
-  List<Object> get props => [messageId, reactionType];
+  List<Object?> get props => [messageId, reactionType, currentUserId];
 }
 
 class MarkMessagesAsReadEvent extends ChatEvent {


### PR DESCRIPTION
Fix reaction and read receipt display issues, ensuring robust chat functionality via FCM without WebSocket dependency.

Reaction FCMs were ignored due to a general `silent=true` handler. Read receipts lacked consistent triggers for marking messages as read and immediate UI updates. Optimistic reaction removal was overly broad, removing all reactions of a type instead of just the current user's.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e628d49-a3db-4b51-bc87-9478d0af5a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e628d49-a3db-4b51-bc87-9478d0af5a2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

