### PR TITLE
Fix chat image upload and display

### DIFF
--- a/control_panel_app/lib/core/widgets/cached_image_widget.dart
+++ b/control_panel_app/lib/core/widgets/cached_image_widget.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:bookn_cp_app/injection_container.dart';
+import 'package:bookn_cp_app/services/local_storage_service.dart';
+import '../constants/storage_constants.dart';
 import '../theme/app_theme.dart';
 import '../theme/app_dimensions.dart';
 import '../utils/image_utils.dart';
@@ -58,6 +61,7 @@ class CachedImageWidget extends StatelessWidget {
               height: height,
               color: color,
               colorBlendMode: colorBlendMode,
+              httpHeaders: _buildAuthHeaders(),
               placeholder: (context, url) => placeholder ?? _buildPlaceholder(),
               errorWidget: (context, url, error) => 
                 errorWidget ?? _buildErrorWidget(),
@@ -72,6 +76,17 @@ class CachedImageWidget extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Map<String, String>? _buildAuthHeaders() {
+    try {
+      final local = sl<LocalStorageService>();
+      final token = local.getData(StorageConstants.accessToken) as String?;
+      if (token != null && token.isNotEmpty) {
+        return {'Authorization': 'Bearer $token'};
+      }
+    } catch (_) {}
+    return null;
   }
 
   Widget _buildPlaceholder() {

--- a/control_panel_app/lib/features/chat/presentation/bloc/chat_event.dart
+++ b/control_panel_app/lib/features/chat/presentation/bloc/chat_event.dart
@@ -210,6 +210,58 @@ class UploadAttachmentEvent extends ChatEvent {
 // Legacy SendImagesEvent and UpdateImageUploadProgressEvent removed. UI now
 // uploads attachments sequentially and shows local progress overlay.
 
+// Begin: In-bubble image upload events
+class StartImageUploadsEvent extends ChatEvent {
+  final String conversationId;
+  final List<ImageUploadInfo> uploads;
+
+  const StartImageUploadsEvent({
+    required this.conversationId,
+    required this.uploads,
+  });
+
+  @override
+  List<Object?> get props => [conversationId, uploads];
+}
+
+class UpdateImageUploadProgressEvent extends ChatEvent {
+  final String conversationId;
+  final String uploadId;
+  final double? progress; // 0.0 - 1.0
+  final bool? isCompleted;
+  final bool? isFailed;
+  final String? error;
+
+  const UpdateImageUploadProgressEvent({
+    required this.conversationId,
+    required this.uploadId,
+    this.progress,
+    this.isCompleted,
+    this.isFailed,
+    this.error,
+  });
+
+  @override
+  List<Object?> get props => [
+        conversationId,
+        uploadId,
+        progress,
+        isCompleted,
+        isFailed,
+        error,
+      ];
+}
+
+class FinishImageUploadsEvent extends ChatEvent {
+  final String conversationId;
+
+  const FinishImageUploadsEvent({required this.conversationId});
+
+  @override
+  List<Object?> get props => [conversationId];
+}
+// End: In-bubble image upload events
+
 class SearchChatsEvent extends ChatEvent {
   final String query;
   final String? conversationId;

--- a/control_panel_app/lib/features/chat/presentation/bloc/chat_state.dart
+++ b/control_panel_app/lib/features/chat/presentation/bloc/chat_state.dart
@@ -98,6 +98,7 @@ class ChatLoaded extends ChatState {
         error,
         uploadingAttachment,
         uploadProgress,
+        uploadingImages,
       ];
 }
 


### PR DESCRIPTION
Implement real-time image upload progress, WhatsApp-style image grid display, and fix image loading failures in chat.

Previously, image uploads lacked progress indication, images were not displayed in a grid format, and crucially, images failed to appear after upload because the backend's attachment download endpoint required authorization, which was missing from the `CachedNetworkImage` requests. This PR adds the necessary `Authorization` header to image requests and introduces a fallback to display images from the message `content` if attachments are not immediately available, preventing empty messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e9989a8-33ed-4faf-bb28-0633404a9223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e9989a8-33ed-4faf-bb28-0633404a9223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

